### PR TITLE
feat: add graceful cancellation and context propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,14 @@ require (
 	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gabriel-vasile/mimetype v1.4.8
+	github.com/google/generative-ai-go v0.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/matoous/go-nanoid/v2 v2.1.0
 	github.com/mattn/go-sqlite3 v1.14.27
 	github.com/openai/openai-go v0.1.0-beta.10
 	github.com/pkoukk/tiktoken-go v0.1.7
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/spachava753/gai v0.4.3
+	github.com/spachava753/gai v0.4.4
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tree-sitter/go-tree-sitter v0.25.0
@@ -24,6 +25,7 @@ require (
 	github.com/tree-sitter/tree-sitter-javascript v0.23.1
 	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
+	google.golang.org/api v0.189.0
 )
 
 require (
@@ -45,7 +47,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/generative-ai-go v0.19.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
@@ -79,7 +80,6 @@ require (
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/api v0.189.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240617180043-68d350f18fd4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240722135656-d784300faade // indirect
 	google.golang.org/grpc v1.64.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
-github.com/spachava753/gai v0.4.3 h1:hthkEg+JSyquacBxVwozBdGZxkNY6Lj3Hq5RdM/Ige0=
-github.com/spachava753/gai v0.4.3/go.mod h1:9dQM77GAFpofStyBXmInEj9jIJ/C6UOxTiTHdWl2cwI=
+github.com/spachava753/gai v0.4.4 h1:+4CB7Bi0omPgGgsv2pF69e6oR7buBnDs9lmPxZFa1EI=
+github.com/spachava753/gai v0.4.4/go.mod h1:9dQM77GAFpofStyBXmInEj9jIJ/C6UOxTiTHdWl2cwI=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=

--- a/internal/storage/dialog_storage.go
+++ b/internal/storage/dialog_storage.go
@@ -416,7 +416,7 @@ func (s *DialogStorage) ListMessages(ctx context.Context) ([]MessageIdNode, erro
 	// Build the forest starting with root nodes
 	var forest []MessageIdNode
 	for _, rootID := range rootMessageIDs {
-		node, err := s.buildMessageTree(rootID, childrenMap)
+		node, err := s.buildMessageTree(ctx, rootID, childrenMap)
 		if err != nil {
 			return nil, err
 		}
@@ -427,15 +427,15 @@ func (s *DialogStorage) ListMessages(ctx context.Context) ([]MessageIdNode, erro
 }
 
 // buildMessageTree recursively builds a message tree starting from the given node ID
-func (s *DialogStorage) buildMessageTree(nodeID string, childrenMap map[string][]string) (MessageIdNode, error) {
+func (s *DialogStorage) buildMessageTree(ctx context.Context, nodeID string, childrenMap map[string][]string) (MessageIdNode, error) {
 	// Get the message from the database to get its parent ID and created_at/role
-	msg, err := s.q.GetMessage(context.Background(), nodeID)
+	msg, err := s.q.GetMessage(ctx, nodeID)
 	if err != nil {
 		return MessageIdNode{}, fmt.Errorf("failed to get message %s: %w", nodeID, err)
 	}
 
 	// Retrieve all blocks for Content extraction
-	blocks, err := s.q.GetBlocksByMessage(context.Background(), nodeID)
+	blocks, err := s.q.GetBlocksByMessage(ctx, nodeID)
 	if err != nil {
 		return MessageIdNode{}, fmt.Errorf("failed to get blocks for message %s: %w", nodeID, err)
 	}
@@ -497,7 +497,7 @@ func (s *DialogStorage) buildMessageTree(nodeID string, childrenMap map[string][
 	children, exists := childrenMap[nodeID]
 	if exists {
 		for _, childID := range children {
-			childNode, err := s.buildMessageTree(childID, childrenMap)
+			childNode, err := s.buildMessageTree(ctx, childID, childrenMap)
 			if err != nil {
 				return MessageIdNode{}, err
 			}


### PR DESCRIPTION
Use signal.NotifyContext and ExecuteContext to listen for SIGINT (user interrupt) and SIGTERM (system/container shutdown), allowing long-running CLI operations to be cancelled gracefully.

- Suppress context.Canceled errors when fetching recent messages or dialog history, generating responses, and saving messages so that cancellations don’t produce error output.
- On interrupt during response generation, warn the user and save any partial dialog; a second interrupt will abort the save.
- Propagate the context into DialogStorage.buildMessageTree and its database queries (GetMessage, GetBlocksByMessage) to allow recursive tree building to be cancelled.

chore: bump and clean up Go module dependencies
- bump github.com/spachava753/gai to v0.4.4
- add github.com/google/generative-ai-go v0.19.0 and google.golang.org/api v0.189.0
- remove duplicate indirect entries