### PR TITLE
refactor: simplify interface naming and invert MCP tool registration control

### DIFF
--- a/internal/agent/block_whitelist_filter.go
+++ b/internal/agent/block_whitelist_filter.go
@@ -12,23 +12,23 @@ type ToolRegister interface {
 	Register(tool gai.Tool, callback gai.ToolCallback) error
 }
 
-// BlockWhitelistFilter wraps a AgentGenerator and filters blocks based on a whitelist of allowed block types.
+// BlockWhitelistFilter wraps a Iface and filters blocks based on a whitelist of allowed block types.
 // Only blocks whose BlockType is in the AllowedTypes slice will be kept.
 type BlockWhitelistFilter struct {
-	generator    AgentGenerator
+	generator    Iface
 	allowedTypes []string
 }
 
 // NewBlockWhitelistFilter creates a new BlockWhitelistFilter with the specified allowed block types.
 // If allowedTypes is empty, all blocks are filtered out (whitelist behavior).
-func NewBlockWhitelistFilter(generator AgentGenerator, allowedTypes []string) *BlockWhitelistFilter {
+func NewBlockWhitelistFilter(generator Iface, allowedTypes []string) *BlockWhitelistFilter {
 	return &BlockWhitelistFilter{
 		generator:    generator,
 		allowedTypes: allowedTypes,
 	}
 }
 
-// Generate wraps the AgentGenerator.Generate method and filters blocks based on the whitelist
+// Generate wraps the Iface.Generate method and filters blocks based on the whitelist
 func (f *BlockWhitelistFilter) Generate(ctx context.Context, dialog gai.Dialog, optsGen gai.GenOptsGenerator) (gai.Dialog, error) {
 	// Filter blocks in each message based on whitelist
 	filteredDialog := make(gai.Dialog, 0, len(dialog))


### PR DESCRIPTION
This commit performs two related refactors to improve code clarity and invert the control flow for MCP tool registration:

1. **Simplified interface naming**: Renamed `AgentGenerator` to `Iface` and made `InitGeneratorFromModel` unexported as `initGeneratorFromModel`. This simplifies the API surface while maintaining the same functionality.

2. **Inverted MCP tool registration**: Refactored the MCP package to return tools and callbacks instead of performing registration directly. The function `RegisterMCPServerTools` has been renamed to `FetchTools` and now returns a map of `gai.Tool` and `gai.ToolCallback` pairs. Registration is now performed at the agent constructor level in `CreateToolCapableGenerator`.

These changes improve separation of concerns - the MCP package focuses on fetching and preparing tools, while the agent package handles registration, providing better control over the tool registration flow.

BREAKING CHANGE: `RegisterMCPServerTools` has been replaced with `FetchTools` which returns tools instead of registering them directly.
