### PR TITLE
Display execution timeout in code mode tool output

### DIFF
--- a/internal/agent/response_printer_test.go
+++ b/internal/agent/response_printer_test.go
@@ -39,6 +39,11 @@ func TestRenderToolCall(t *testing.T) {
 		{
 			name:    "execute_go_code renders as Go block",
 			content: `{"name":"execute_go_code","parameters":{"code":"package main\n\nfunc Run() error { return nil }","executionTimeout":30}}`,
+			want:    "#### [tool call] (timeout: 30s)\n```go\npackage main\n\nfunc Run() error { return nil }\n```",
+		},
+		{
+			name:    "execute_go_code without timeout renders without timeout",
+			content: `{"name":"execute_go_code","parameters":{"code":"package main\n\nfunc Run() error { return nil }"}}`,
 			want:    "#### [tool call]\n```go\npackage main\n\nfunc Run() error { return nil }\n```",
 		},
 		{

--- a/internal/codemode/tool.go
+++ b/internal/codemode/tool.go
@@ -9,7 +9,7 @@ import (
 )
 
 // executeGoCodeInput represents the input parameters for the execute_go_code tool
-type executeGoCodeInput struct {
+type ExecuteGoCodeInput struct {
 	Code             string `json:"code"`
 	ExecutionTimeout int    `json:"executionTimeout"`
 }
@@ -28,7 +28,7 @@ type ExecuteGoCodeCallback struct {
 //   - Infrastructure errors: error that stops agent execution
 func (c *ExecuteGoCodeCallback) Call(ctx context.Context, parametersJSON json.RawMessage, toolCallID string) (gai.Message, error) {
 	// Parse input parameters
-	var input executeGoCodeInput
+	var input ExecuteGoCodeInput
 	if err := json.Unmarshal(parametersJSON, &input); err != nil {
 		return gai.ToolResultMessage(toolCallID, gai.Text, "text/plain", gai.Str("Error parsing parameters: "+err.Error())), nil
 	}

--- a/internal/codemode/tool_test.go
+++ b/internal/codemode/tool_test.go
@@ -13,7 +13,7 @@ import (
 func TestExecuteGoCodeCallback_Call(t *testing.T) {
 	tests := []struct {
 		name           string
-		input          executeGoCodeInput
+		input          ExecuteGoCodeInput
 		wantErr        bool
 		wantFatalErr   bool
 		wantOutputSub  string // substring expected in output
@@ -21,7 +21,7 @@ func TestExecuteGoCodeCallback_Call(t *testing.T) {
 	}{
 		{
 			name: "successful execution",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 import (
@@ -40,7 +40,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "compilation error - syntax",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 func Run(ctx context.Context) error {
@@ -54,7 +54,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "compilation error - missing import",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 func Run(ctx context.Context) error {
@@ -68,7 +68,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "Run returns error - exit code 1",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 import (
@@ -86,7 +86,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "panic - exit code 2",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 import "context"
@@ -101,7 +101,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "fatal exit - exit code 3",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 import (
@@ -124,7 +124,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "timeout exceeded",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code: `package main
 
 import (
@@ -144,7 +144,7 @@ func Run(ctx context.Context) error {
 		},
 		{
 			name: "invalid JSON parameters",
-			input: executeGoCodeInput{
+			input: ExecuteGoCodeInput{
 				Code:             "", // Will test with raw invalid JSON
 				ExecutionTimeout: 0,
 			},
@@ -238,7 +238,7 @@ func TestExecuteGoCodeCallback_ContextCancellation(t *testing.T) {
 
 	callback := &ExecuteGoCodeCallback{Servers: nil}
 
-	input := executeGoCodeInput{
+	input := ExecuteGoCodeInput{
 		Code: `package main
 
 import (


### PR DESCRIPTION
Fixes #106

Shows the executionTimeout parameter when rendering execute_go_code tool calls. When a timeout is specified, the output header displays it as "#### [tool call] (timeout: 30s)".

This improves visibility for users debugging time-sensitive or long-running scripts.