### PR TITLE
Display tool execution results in terminal

### DIFF
--- a/internal/agent/response_printer.go
+++ b/internal/agent/response_printer.go
@@ -17,6 +17,31 @@ import (
 	"golang.org/x/term"
 )
 
+
+// newContentRenderer creates a glamour renderer for content with appropriate styling
+func newContentRenderer() (Renderer, error) {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		style := styles.NoTTYStyleConfig
+		style.Document.BlockPrefix = ""
+
+		return glamour.NewTermRenderer(
+			glamour.WithStyles(style),
+			glamour.WithWordWrap(120),
+		)
+	}
+
+	style := styles.LightStyleConfig
+	if termenv.HasDarkBackground() {
+		style = styles.DarkStyleConfig
+	}
+	style.Document.BlockPrefix = ""
+
+	return glamour.NewTermRenderer(
+		glamour.WithStyles(style),
+		glamour.WithWordWrap(120),
+	)
+}
+
 type Renderer interface {
 	Render(in string) (string, error)
 }

--- a/internal/agent/tool_result_printer.go
+++ b/internal/agent/tool_result_printer.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spachava753/cpe/internal/codemode"
+	"github.com/spachava753/gai"
+)
+
+const maxLines = 20
+
+// ToolCallbackPrinter wraps a ToolCallback and prints its results to stderr
+type ToolCallbackPrinter struct {
+	wrapped  gai.ToolCallback
+	toolName string
+	renderer Renderer
+}
+
+// Call executes the wrapped callback and prints the result
+func (p *ToolCallbackPrinter) Call(ctx context.Context, parametersJSON json.RawMessage, toolCallID string) (gai.Message, error) {
+	// Execute the wrapped callback
+	msg, err := p.wrapped.Call(ctx, parametersJSON, toolCallID)
+	if err != nil {
+		return msg, err
+	}
+
+	// Print the result
+	p.printResult(msg)
+
+	return msg, nil
+}
+
+// printResult prints the tool result to stderr with truncation and rendering
+func (p *ToolCallbackPrinter) printResult(msg gai.Message) {
+	var output strings.Builder
+	
+	// Determine if this is execute_go_code or a regular tool
+	isCodeMode := p.toolName == codemode.ExecuteGoCodeToolName
+	
+	// Collect all text content from blocks
+	var content strings.Builder
+	for _, block := range msg.Blocks {
+		if block.ModalityType == gai.Text {
+			content.WriteString(block.Content.String())
+		}
+	}
+	
+	contentStr := content.String()
+	
+	// Truncate to maxLines first
+	truncated := truncateToLines(contentStr, maxLines)
+	
+	// Build markdown content based on tool type
+	var markdownContent string
+	if isCodeMode {
+		// For code mode, wrap in a text code block
+		markdownContent = fmt.Sprintf("#### Code execution output:\n" + "````shell\n%s\n" + "````", truncated)
+	} else {
+		// For regular tools, try to format as JSON
+		var jsonData interface{}
+		if err := json.Unmarshal([]byte(contentStr), &jsonData); err == nil {
+			// Valid JSON, pretty print it
+			formatted, err := json.MarshalIndent(jsonData, "", "  ")
+			if err == nil {
+				// Truncate the formatted JSON
+				truncated = truncateToLines(string(formatted), maxLines)
+			}
+			markdownContent = fmt.Sprintf("#### Tool \"%s\" result:\n" + "```json\n%s\n" + "```", p.toolName, truncated)
+		} else {
+			// Not JSON, treat as plain text
+			markdownContent = fmt.Sprintf("#### Tool \"%s\" result:\n" + "```\n%s\n" + "```", p.toolName, truncated)
+		}
+	}
+	
+	// Render with glamour
+	rendered, err := p.renderer.Render(markdownContent)
+	if err != nil {
+		// Fallback to plain text if rendering fails
+		output.WriteString("\n")
+		output.WriteString(markdownContent)
+		output.WriteString("\n")
+	} else {
+		output.WriteString("\n")
+		output.WriteString(rendered)
+	}
+	
+	// Write to stderr
+	fmt.Fprint(os.Stderr, output.String())
+}
+
+// truncateToLines truncates content to the specified number of lines
+func truncateToLines(content string, maxLines int) string {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	var lines []string
+	lineCount := 0
+	
+	for scanner.Scan() && lineCount < maxLines {
+		lines = append(lines, scanner.Text())
+		lineCount++
+	}
+	
+	// Check if there are more lines
+	if scanner.Scan() {
+		lines = append(lines, "... (truncated)")
+	}
+	
+	return strings.Join(lines, "\n")
+}
+
+// ToolResultPrinterWrapper wraps an Iface and prints tool execution results
+type ToolResultPrinterWrapper struct {
+	wrapped  Iface
+	renderer Renderer
+}
+
+// NewToolResultPrinterWrapper creates a new ToolResultPrinterWrapper with a glamour renderer
+func NewToolResultPrinterWrapper(wrapped Iface, renderer Renderer) *ToolResultPrinterWrapper {
+	return &ToolResultPrinterWrapper{
+		wrapped:  wrapped,
+		renderer: renderer,
+	}
+}
+
+// Generate delegates to the wrapped generator
+func (g *ToolResultPrinterWrapper) Generate(ctx context.Context, dialog gai.Dialog, optsGen gai.GenOptsGenerator) (gai.Dialog, error) {
+	return g.wrapped.Generate(ctx, dialog, optsGen)
+}
+
+// Register wraps the callback with a printer and registers it with the wrapped generator
+func (g *ToolResultPrinterWrapper) Register(tool gai.Tool, callback gai.ToolCallback) error {
+	// Wrap the callback with our printer
+	wrappedCallback := &ToolCallbackPrinter{
+		wrapped:  callback,
+		toolName: tool.Name,
+		renderer: g.renderer,
+	}
+	
+	// Register with the wrapped generator using the local ToolRegister interface
+	if toolRegister, ok := g.wrapped.(ToolRegister); ok {
+		return toolRegister.Register(tool, wrappedCallback)
+	}
+	
+	return gai.ToolRegistrationErr{Tool: tool.Name, Cause: fmt.Errorf("underlying generator does not support tool registration")}
+}

--- a/internal/agent/tool_result_printer_test.go
+++ b/internal/agent/tool_result_printer_test.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spachava753/cpe/internal/codemode"
+	"github.com/spachava753/gai"
+)
+
+// mockToolCallback is a mock implementation of gai.ToolCallback for testing
+type mockToolCallback struct {
+	response string
+}
+
+func (m *mockToolCallback) Call(ctx context.Context, parametersJSON json.RawMessage, toolCallID string) (gai.Message, error) {
+	return gai.Message{
+		Role: gai.ToolResult,
+		Blocks: []gai.Block{
+			{
+				ID:           toolCallID,
+				BlockType:    gai.Content,
+				ModalityType: gai.Text,
+				MimeType:     "text/plain",
+				Content:      gai.Str(m.response),
+			},
+		},
+	}, nil
+}
+
+func TestToolCallbackPrinter(t *testing.T) {
+	tests := []struct {
+		name             string
+		toolName         string
+		callbackResponse string
+		expectedBlocks   int
+		validateContent  func(t *testing.T, content string)
+	}{
+		{
+			name:             "prints JSON for regular tool",
+			toolName:         "get_weather",
+			callbackResponse: `{"temperature": 72, "condition": "sunny"}`,
+			expectedBlocks:   1,
+			validateContent: func(t *testing.T, content string) {
+				if content != `{"temperature": 72, "condition": "sunny"}` {
+					t.Errorf("unexpected content: %s", content)
+				}
+			},
+		},
+		{
+			name:             "prints text for code mode",
+			toolName:         codemode.ExecuteGoCodeToolName,
+			callbackResponse: "The weather is sunny and 72 degrees",
+			expectedBlocks:   1,
+			validateContent: func(t *testing.T, content string) {
+				if content != "The weather is sunny and 72 degrees" {
+					t.Errorf("unexpected content: %s", content)
+				}
+			},
+		},
+		{
+			name:             "truncates long output",
+			toolName:         "test_tool",
+			callbackResponse: strings.Join(makeLines(25), "\n"),
+			expectedBlocks:   1,
+			validateContent: func(t *testing.T, content string) {
+				expected := strings.Join(makeLines(25), "\n")
+				if content != expected {
+					t.Errorf("message content was modified, should not be")
+				}
+			},
+		},
+		{
+			name:             "handles empty response",
+			toolName:         "empty_tool",
+			callbackResponse: "",
+			expectedBlocks:   1,
+			validateContent: func(t *testing.T, content string) {
+				if content != "" {
+					t.Errorf("expected empty content, got: %s", content)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCallback := &mockToolCallback{
+				response: tt.callbackResponse,
+			}
+
+			printer := &ToolCallbackPrinter{
+				wrapped:  mockCallback,
+				toolName: tt.toolName,
+				renderer: &mockRenderer{
+					renderFunc: func(in string) (string, error) {
+						return in, nil
+					},
+				},
+			}
+
+			msg, err := printer.Call(context.Background(), json.RawMessage("{}"), "test-id")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(msg.Blocks) != tt.expectedBlocks {
+				t.Fatalf("expected %d block(s), got %d", tt.expectedBlocks, len(msg.Blocks))
+			}
+
+			if tt.validateContent != nil {
+				tt.validateContent(t, msg.Blocks[0].Content.String())
+			}
+		})
+	}
+}
+
+func TestTruncateToLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		maxLines int
+		want     string
+	}{
+		{
+			name:     "content shorter than max",
+			content:  "line1\nline2\nline3",
+			maxLines: 5,
+			want:     "line1\nline2\nline3",
+		},
+		{
+			name:     "content exactly at max",
+			content:  "line1\nline2\nline3",
+			maxLines: 3,
+			want:     "line1\nline2\nline3",
+		},
+		{
+			name:     "content longer than max",
+			content:  "line1\nline2\nline3\nline4\nline5",
+			maxLines: 3,
+			want:     "line1\nline2\nline3\n... (truncated)",
+		},
+		{
+			name:     "single line",
+			content:  "single line",
+			maxLines: 20,
+			want:     "single line",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			maxLines: 20,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateToLines(tt.content, tt.maxLines)
+			if got != tt.want {
+				t.Errorf("truncateToLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// makeLines generates n lines of test content
+func makeLines(n int) []string {
+	var lines []string
+	for i := 1; i <= n; i++ {
+		lines = append(lines, fmt.Sprintf("Line %d", i))
+	}
+	return lines
+}


### PR DESCRIPTION
## Summary

Adds visibility into tool execution by displaying results to stderr during agent runs. Users can now see what data tools return, making it easier to verify tool behavior and debug issues when the agent acts on incorrect information.

## Changes

Tool results are now printed to stderr with glamour markdown rendering:
- JSON responses are automatically pretty-printed in json code blocks
- Code execution output appears in shell code blocks
- Results are truncated to 20 lines to keep output manageable
- Styling is consistent with the response printer

## Implementation

- Added tool callback wrapper that intercepts tool results and prints them
- Integrated wrapper into the generator middleware chain
- Created shared content renderer helper for consistent styling
- Added table-driven tests for various tool result scenarios

## Example Output

**Regular MCP Tool:**
````markdown
#### Tool "get_weather" result:
```json
{
  "condition": "sunny",
  "temperature": 72
}
```
````

**Code Execution:**
````markdown
#### Code execution output:
```shell
Reading file data.txt...
Found 5 matches.
```
````

Closes #105