### PR TITLE
feat(codemode): configurable max execution timeout

### DIFF
--- a/docs/specs/code_mode_token_comparison_test.go
+++ b/docs/specs/code_mode_token_comparison_test.go
@@ -114,7 +114,7 @@ func TestCodeModeTokenComparison(t *testing.T) {
 		codeModeSvc := gai.NewAnthropicServiceWrapper(&codeModeClient.Messages)
 		codeModeGen := gai.NewAnthropicGenerator(codeModeSvc, "claude-sonnet-4-20250514", "")
 
-		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{getCityTool, getWeatherTool})
+		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{getCityTool, getWeatherTool}, 300)
 		if err != nil {
 			t.Fatalf("failed to generate execute_go_code tool: %v", err)
 		}
@@ -244,7 +244,7 @@ func Run(ctx context.Context) error {
 		codeModeSvc := gai.NewAnthropicServiceWrapper(&codeModeClient.Messages)
 		codeModeGen := gai.NewAnthropicGenerator(codeModeSvc, "claude-sonnet-4-20250514", "")
 
-		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{getWeatherTool})
+		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{getWeatherTool}, 300)
 		if err != nil {
 			t.Fatalf("failed to generate execute_go_code tool: %v", err)
 		}
@@ -363,7 +363,7 @@ func Run(ctx context.Context) error {
 		codeModeSvc := gai.NewAnthropicServiceWrapper(&codeModeClient.Messages)
 		codeModeGen := gai.NewAnthropicGenerator(codeModeSvc, "claude-sonnet-4-20250514", "")
 
-		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{getCityTool, getWeatherTool})
+		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{getCityTool, getWeatherTool}, 300)
 		if err != nil {
 			t.Fatalf("failed to generate execute_go_code tool: %v", err)
 		}
@@ -462,7 +462,7 @@ func Run(ctx context.Context) error {
 		codeModeSvc := gai.NewAnthropicServiceWrapper(&codeModeClient.Messages)
 		codeModeGen := gai.NewAnthropicGenerator(codeModeSvc, "claude-sonnet-4-20250514", "")
 
-		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{})
+		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool([]*mcp.Tool{}, 300)
 		if err != nil {
 			t.Fatalf("failed to generate execute_go_code tool: %v", err)
 		}

--- a/internal/agent/generator.go
+++ b/internal/agent/generator.go
@@ -184,7 +184,7 @@ func CreateToolCapableGenerator(
 
 		// Always register execute_go_code when code mode is enabled, even without MCP tools.
 		// The tool provides access to the Go standard library for file I/O, etc.
-		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool(allCodeModeTools)
+		executeGoCodeTool, err := codemode.GenerateExecuteGoCodeTool(allCodeModeTools, codeModeConfig.MaxTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate execute_go_code tool: %w", err)
 		}

--- a/internal/codemode/tooldesc_test.go
+++ b/internal/codemode/tooldesc_test.go
@@ -268,16 +268,20 @@ IMPORTANT: Generate the complete file contents including package declaration and
 
 func TestGenerateExecuteGoCodeTool(t *testing.T) {
 	tests := []struct {
-		name    string
-		tools   []*mcp.Tool
-		wantErr bool
+		name       string
+		tools      []*mcp.Tool
+		maxTimeout int
+		wantMax    float64
+		wantErr    bool
 	}{
 		{
-			name:  "empty tools",
-			tools: []*mcp.Tool{},
+			name:       "empty tools, default timeout",
+			tools:      []*mcp.Tool{},
+			maxTimeout: 0,
+			wantMax:    300,
 		},
 		{
-			name: "with tools",
+			name: "with tools, custom timeout",
 			tools: []*mcp.Tool{
 				{
 					Name:        "test_tool",
@@ -291,12 +295,14 @@ func TestGenerateExecuteGoCodeTool(t *testing.T) {
 					OutputSchema: nil,
 				},
 			},
+			maxTimeout: 600,
+			wantMax:    600,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool, err := GenerateExecuteGoCodeTool(tt.tools)
+			tool, err := GenerateExecuteGoCodeTool(tt.tools, tt.maxTimeout)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateExecuteGoCodeTool() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -347,8 +353,8 @@ func TestGenerateExecuteGoCodeTool(t *testing.T) {
 				if timeoutProp.Minimum == nil || *timeoutProp.Minimum != 1 {
 					t.Error("executionTimeout.Minimum should be 1")
 				}
-				if timeoutProp.Maximum == nil || *timeoutProp.Maximum != 300 {
-					t.Error("executionTimeout.Maximum should be 300")
+				if timeoutProp.Maximum == nil || *timeoutProp.Maximum != tt.wantMax {
+					t.Errorf("executionTimeout.Maximum = %v, want %v", *timeoutProp.Maximum, tt.wantMax)
 				}
 			}
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type PatchRequestConfig struct {
 type CodeModeConfig struct {
 	Enabled       bool     `yaml:"enabled" json:"enabled"`
 	ExcludedTools []string `yaml:"excludedTools,omitempty" json:"excludedTools,omitempty"`
+	MaxTimeout    int      `yaml:"maxTimeout,omitempty" json:"maxTimeout,omitempty" validate:"omitempty,gte=0"`
 }
 
 // RawConfig represents the configuration file structure


### PR DESCRIPTION
Allow users to configure the maximum execution timeout for code mode via the `maxTimeout` field in `CodeModeConfig`. This addresses the limitation where the timeout was hardcoded to 300 seconds (5 minutes), which might be insufficient for long-running tasks like analyzing large codebases or running extensive tests.

The `execute_go_code` tool definition now dynamically reflects the configured maximum timeout in its schema description and validation limits. The default behavior remains 300 seconds if the configuration is omitted or set to 0.

Closes #114