### PR TITLE
feat(auth): add Anthropic OAuth support for Claude Pro/Max subscriptions

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spachava753/cpe/internal/auth"
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage authentication for AI providers",
+	Long:  "Manage OAuth authentication for AI providers like Anthropic Claude Pro/Max subscriptions.",
+}
+
+var authLoginCmd = &cobra.Command{
+	Use:   "login [provider]",
+	Short: "Authenticate with an AI provider via OAuth",
+	Long: `Start an OAuth flow to authenticate with an AI provider.
+
+Currently supported providers:
+  - anthropic: Authenticate with Claude Pro/Max subscription
+
+Example:
+  cpe auth login anthropic
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider := strings.ToLower(args[0])
+		switch provider {
+		case "anthropic":
+			return loginAnthropic(cmd)
+		default:
+			return fmt.Errorf("unsupported provider %q (supported: anthropic)", provider)
+		}
+	},
+}
+
+var authLogoutCmd = &cobra.Command{
+	Use:   "logout [provider]",
+	Short: "Remove stored credentials for a provider",
+	Long: `Remove stored OAuth credentials for an AI provider.
+
+Example:
+  cpe auth logout anthropic
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider := strings.ToLower(args[0])
+
+		store, err := auth.NewStore()
+		if err != nil {
+			return fmt.Errorf("initializing auth store: %w", err)
+		}
+
+		if err := store.DeleteCredential(provider); err != nil {
+			return fmt.Errorf("removing credential: %w", err)
+		}
+
+		fmt.Printf("Successfully logged out from %s\n", provider)
+		return nil
+	},
+}
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show authentication status for all providers",
+	Long: `Display the current authentication status for all configured providers.
+
+Example:
+  cpe auth status
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := auth.NewStore()
+		if err != nil {
+			return fmt.Errorf("initializing auth store: %w", err)
+		}
+
+		providers, err := store.ListCredentials()
+		if err != nil {
+			return fmt.Errorf("listing credentials: %w", err)
+		}
+
+		if len(providers) == 0 {
+			fmt.Println("No providers authenticated")
+			fmt.Println("\nTo authenticate with Anthropic:")
+			fmt.Println("  cpe auth login anthropic")
+			return nil
+		}
+
+		fmt.Println("Authenticated providers:")
+		for _, p := range providers {
+			cred, err := store.GetCredential(p)
+			if err != nil {
+				fmt.Printf("  %s: error reading credential\n", p)
+				continue
+			}
+
+			status := "valid"
+			if cred.IsExpired() {
+				status = "expired (will refresh on next use)"
+			} else if cred.ExpiresAt > 0 {
+				remaining := time.Until(time.Unix(cred.ExpiresAt, 0))
+				status = fmt.Sprintf("valid (expires in %s)", remaining.Round(time.Minute))
+			}
+
+			fmt.Printf("  %s: %s\n", p, status)
+		}
+
+		return nil
+	},
+}
+
+func loginAnthropic(cmd *cobra.Command) error {
+	// Generate PKCE challenge
+	verifier, challenge, err := auth.GeneratePKCE()
+	if err != nil {
+		return fmt.Errorf("generating PKCE challenge: %w", err)
+	}
+
+	// Build authorization URL (state is set to verifier per Anthropic's OAuth)
+	authURL := auth.BuildAuthURL(challenge, verifier)
+
+	fmt.Println("Opening browser to authenticate with Anthropic...")
+	fmt.Println()
+	fmt.Println("If the browser doesn't open, visit this URL manually:")
+	fmt.Println(authURL)
+	fmt.Println()
+
+	// Try to open browser
+	if err := auth.OpenBrowser(authURL); err != nil {
+		fmt.Println("Note: Could not open browser automatically")
+	}
+
+	fmt.Println("After authorizing, you'll see a page with an authorization code.")
+	fmt.Print("Paste the authorization code here: ")
+
+	// Read the authorization code from stdin
+	reader := bufio.NewReader(os.Stdin)
+	code, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading authorization code: %w", err)
+	}
+	code = strings.TrimSpace(code)
+
+	if code == "" {
+		return fmt.Errorf("authorization code cannot be empty")
+	}
+
+	// Pass the full code#state to ExchangeCode which will parse it
+
+	fmt.Println()
+	fmt.Println("Exchanging code for tokens...")
+
+	// Exchange the code for tokens
+	tokenResp, err := auth.ExchangeCode(cmd.Context(), code, verifier)
+	if err != nil {
+		return fmt.Errorf("exchanging code for tokens: %w", err)
+	}
+
+	// Store the credential
+	store, err := auth.NewStore()
+	if err != nil {
+		return fmt.Errorf("initializing auth store: %w", err)
+	}
+
+	cred := auth.TokenToCredential(tokenResp)
+	if err := store.SaveCredential(cred); err != nil {
+		return fmt.Errorf("saving credential: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println("✓ Successfully authenticated with Anthropic!")
+	fmt.Println()
+	fmt.Println("You can now use your Claude Pro/Max subscription with CPE.")
+	fmt.Println("OAuth credentials will be used automatically when no API key is configured.")
+
+	return nil
+}
+
+func init() {
+	authCmd.AddCommand(authLoginCmd)
+	authCmd.AddCommand(authLogoutCmd)
+	authCmd.AddCommand(authStatusCmd)
+	rootCmd.AddCommand(authCmd)
+}

--- a/internal/agent/generator_test.go
+++ b/internal/agent/generator_test.go
@@ -42,7 +42,7 @@ func TestCodeModeToolRegistration(t *testing.T) {
 			wantTools:      []string{codemode.ExecuteGoCodeToolName},
 		},
 		{
-			name: "code mode disabled with no servers does not register execute_go_code",
+			name:           "code mode disabled with no servers does not register execute_go_code",
 			codeModeConfig: &config.CodeModeConfig{Enabled: false},
 			toolsByServer:  map[string][]mcp.ToolData{},
 			mcpServers:     map[string]mcp.ServerConfig{},

--- a/internal/agent/response_printer.go
+++ b/internal/agent/response_printer.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/term"
 )
 
-
 // newContentRenderer creates a glamour renderer for content with appropriate styling
 func newContentRenderer() (Renderer, error) {
 	if !term.IsTerminal(int(os.Stdout.Fd())) {

--- a/internal/agent/response_printer_test.go
+++ b/internal/agent/response_printer_test.go
@@ -115,18 +115,18 @@ func TestRenderToolCall(t *testing.T) {
 
 func TestRenderToolCallUsesCorrectRenderer(t *testing.T) {
 	tests := []struct {
-		name               string
-		content            string
+		name                string
+		content             string
 		wantContentRenderer bool
 	}{
 		{
-			name:               "execute_go_code uses contentRenderer",
-			content:            `{"name":"execute_go_code","parameters":{"code":"package main","executionTimeout":30}}`,
+			name:                "execute_go_code uses contentRenderer",
+			content:             `{"name":"execute_go_code","parameters":{"code":"package main","executionTimeout":30}}`,
 			wantContentRenderer: true,
 		},
 		{
-			name:               "regular tool uses toolCallRenderer",
-			content:            `{"name":"get_weather","parameters":{"city":"NYC"}}`,
+			name:                "regular tool uses toolCallRenderer",
+			content:             `{"name":"get_weather","parameters":{"city":"NYC"}}`,
 			wantContentRenderer: false,
 		},
 	}

--- a/internal/agent/tool_result_printer.go
+++ b/internal/agent/tool_result_printer.go
@@ -38,10 +38,10 @@ func (p *ToolCallbackPrinter) Call(ctx context.Context, parametersJSON json.RawM
 // printResult prints the tool result to stderr with truncation and rendering
 func (p *ToolCallbackPrinter) printResult(msg gai.Message) {
 	var output strings.Builder
-	
+
 	// Determine if this is execute_go_code or a regular tool
 	isCodeMode := p.toolName == codemode.ExecuteGoCodeToolName
-	
+
 	// Collect all text content from blocks
 	var content strings.Builder
 	for _, block := range msg.Blocks {
@@ -49,17 +49,17 @@ func (p *ToolCallbackPrinter) printResult(msg gai.Message) {
 			content.WriteString(block.Content.String())
 		}
 	}
-	
+
 	contentStr := content.String()
-	
+
 	// Truncate to maxLines first
 	truncated := truncateToLines(contentStr, maxLines)
-	
+
 	// Build markdown content based on tool type
 	var markdownContent string
 	if isCodeMode {
 		// For code mode, wrap in a text code block
-		markdownContent = fmt.Sprintf("#### Code execution output:\n" + "````shell\n%s\n" + "````", truncated)
+		markdownContent = fmt.Sprintf("#### Code execution output:\n"+"````shell\n%s\n"+"````", truncated)
 	} else {
 		// For regular tools, try to format as JSON
 		var jsonData interface{}
@@ -70,13 +70,13 @@ func (p *ToolCallbackPrinter) printResult(msg gai.Message) {
 				// Truncate the formatted JSON
 				truncated = truncateToLines(string(formatted), maxLines)
 			}
-			markdownContent = fmt.Sprintf("#### Tool \"%s\" result:\n" + "```json\n%s\n" + "```", p.toolName, truncated)
+			markdownContent = fmt.Sprintf("#### Tool \"%s\" result:\n"+"```json\n%s\n"+"```", p.toolName, truncated)
 		} else {
 			// Not JSON, treat as plain text
-			markdownContent = fmt.Sprintf("#### Tool \"%s\" result:\n" + "```\n%s\n" + "```", p.toolName, truncated)
+			markdownContent = fmt.Sprintf("#### Tool \"%s\" result:\n"+"```\n%s\n"+"```", p.toolName, truncated)
 		}
 	}
-	
+
 	// Render with glamour
 	rendered, err := p.renderer.Render(markdownContent)
 	if err != nil {
@@ -88,7 +88,7 @@ func (p *ToolCallbackPrinter) printResult(msg gai.Message) {
 		output.WriteString("\n")
 		output.WriteString(rendered)
 	}
-	
+
 	// Write to stderr
 	fmt.Fprint(os.Stderr, output.String())
 }
@@ -98,17 +98,17 @@ func truncateToLines(content string, maxLines int) string {
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	var lines []string
 	lineCount := 0
-	
+
 	for scanner.Scan() && lineCount < maxLines {
 		lines = append(lines, scanner.Text())
 		lineCount++
 	}
-	
+
 	// Check if there are more lines
 	if scanner.Scan() {
 		lines = append(lines, "... (truncated)")
 	}
-	
+
 	return strings.Join(lines, "\n")
 }
 
@@ -139,11 +139,11 @@ func (g *ToolResultPrinterWrapper) Register(tool gai.Tool, callback gai.ToolCall
 		toolName: tool.Name,
 		renderer: g.renderer,
 	}
-	
+
 	// Register with the wrapped generator using the local ToolRegister interface
 	if toolRegister, ok := g.wrapped.(ToolRegister); ok {
 		return toolRegister.Register(tool, wrappedCallback)
 	}
-	
+
 	return gai.ToolRegistrationErr{Tool: tool.Name, Cause: fmt.Errorf("underlying generator does not support tool registration")}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Credential represents stored authentication credentials
+type Credential struct {
+	Type         string `json:"type"`     // "oauth"
+	Provider     string `json:"provider"` // "anthropic"
+	AccessToken  string `json:"access"`
+	RefreshToken string `json:"refresh"`
+	ExpiresAt    int64  `json:"expires"`
+}
+
+// IsExpired returns true if the credential has expired
+func (c *Credential) IsExpired() bool {
+	return c.ExpiresAt > 0 && time.Now().Unix() >= c.ExpiresAt
+}
+
+// Store manages credential persistence
+type Store struct {
+	path string
+	mu   sync.RWMutex
+}
+
+// NewStore creates a new credential store at the default location (~/.config/cpe/auth.json)
+func NewStore() (*Store, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("getting user config dir: %w", err)
+	}
+
+	cpeDir := filepath.Join(configDir, "cpe")
+	if err := os.MkdirAll(cpeDir, 0700); err != nil {
+		return nil, fmt.Errorf("creating config dir: %w", err)
+	}
+
+	return &Store{
+		path: filepath.Join(cpeDir, "auth.json"),
+	}, nil
+}
+
+// loadAll reads all credentials from disk
+func (s *Store) loadAll() (map[string]*Credential, error) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return make(map[string]*Credential), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading auth file: %w", err)
+	}
+
+	var creds map[string]*Credential
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parsing auth file: %w", err)
+	}
+
+	if creds == nil {
+		creds = make(map[string]*Credential)
+	}
+	return creds, nil
+}
+
+// saveAll writes all credentials to disk
+func (s *Store) saveAll(creds map[string]*Credential) error {
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling credentials: %w", err)
+	}
+
+	if err := os.WriteFile(s.path, data, 0600); err != nil {
+		return fmt.Errorf("writing auth file: %w", err)
+	}
+
+	return nil
+}
+
+// GetCredential retrieves a credential for the given provider
+func (s *Store) GetCredential(provider string) (*Credential, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	creds, err := s.loadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	cred, ok := creds[provider]
+	if !ok {
+		return nil, fmt.Errorf("no credential found for provider %q", provider)
+	}
+
+	return cred, nil
+}
+
+// SaveCredential stores a credential for the given provider
+func (s *Store) SaveCredential(cred *Credential) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	creds, err := s.loadAll()
+	if err != nil {
+		return err
+	}
+
+	creds[cred.Provider] = cred
+	return s.saveAll(creds)
+}
+
+// DeleteCredential removes a credential for the given provider
+func (s *Store) DeleteCredential(provider string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	creds, err := s.loadAll()
+	if err != nil {
+		return err
+	}
+
+	if _, ok := creds[provider]; !ok {
+		return fmt.Errorf("no credential found for provider %q", provider)
+	}
+
+	delete(creds, provider)
+	return s.saveAll(creds)
+}
+
+// ListCredentials returns all stored providers
+func (s *Store) ListCredentials() ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	creds, err := s.loadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var providers []string
+	for p := range creds {
+		providers = append(providers, p)
+	}
+	return providers, nil
+}
+
+// GetCredential is a convenience function that creates a store and retrieves a credential
+func GetCredential(provider string) (*Credential, error) {
+	store, err := NewStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetCredential(provider)
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -20,7 +20,7 @@ const (
 	AnthropicTokenURL    = "https://console.anthropic.com/v1/oauth/token"
 	AnthropicRedirectURI = "https://console.anthropic.com/oauth/code/callback"
 	AnthropicScopes      = "org:create_api_key user:profile user:inference"
-	AnthropicBetaHeader  = "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+	AnthropicBetaHeader  = "oauth-2025-04-20,claude-code-20250219"
 )
 
 // TokenResponse represents the OAuth token response from Anthropic

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -48,8 +48,6 @@ func BuildAuthURL(challenge, verifier string) string {
 	return AnthropicAuthURL + "?" + params.Encode()
 }
 
-
-
 // OpenBrowser opens the default browser to the given URL
 func OpenBrowser(url string) error {
 	var cmd *exec.Cmd

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,168 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// OAuth constants for Anthropic
+const (
+	AnthropicClientID    = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+	AnthropicAuthURL     = "https://claude.ai/oauth/authorize"
+	AnthropicTokenURL    = "https://console.anthropic.com/v1/oauth/token"
+	AnthropicRedirectURI = "https://console.anthropic.com/oauth/code/callback"
+	AnthropicScopes      = "org:create_api_key user:profile user:inference"
+	AnthropicBetaHeader  = "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+)
+
+// TokenResponse represents the OAuth token response from Anthropic
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+// BuildAuthURL constructs the OAuth authorization URL with PKCE parameters
+// Note: state is set to the verifier per Anthropic's OAuth implementation
+func BuildAuthURL(challenge, verifier string) string {
+	params := url.Values{
+		"code":                  {"true"},
+		"client_id":             {AnthropicClientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {AnthropicRedirectURI},
+		"scope":                 {AnthropicScopes},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {verifier},
+	}
+	return AnthropicAuthURL + "?" + params.Encode()
+}
+
+
+
+// OpenBrowser opens the default browser to the given URL
+func OpenBrowser(url string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default: // linux and others
+		cmd = exec.Command("xdg-open", url)
+	}
+
+	return cmd.Start()
+}
+
+// ExchangeCode exchanges an authorization code for tokens
+// The code parameter should be in the format "code#state" as returned by the callback
+func ExchangeCode(ctx context.Context, code, verifier string) (*TokenResponse, error) {
+	// Split code#state format
+	authCode := code
+	state := ""
+	if idx := strings.Index(code, "#"); idx != -1 {
+		authCode = code[:idx]
+		state = code[idx+1:]
+	}
+
+	payload := map[string]string{
+		"code":          authCode,
+		"state":         state,
+		"grant_type":    "authorization_code",
+		"client_id":     AnthropicClientID,
+		"redirect_uri":  AnthropicRedirectURI,
+		"code_verifier": verifier,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling token request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", AnthropicTokenURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]any
+		json.NewDecoder(resp.Body).Decode(&errBody)
+		return nil, fmt.Errorf("token exchange failed (status %d): %v", resp.StatusCode, errBody)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+
+	return &tokenResp, nil
+}
+
+// RefreshAccessToken uses the refresh token to get a new access token
+func RefreshAccessToken(ctx context.Context, refreshToken string) (*TokenResponse, error) {
+	payload := map[string]string{
+		"grant_type":    "refresh_token",
+		"client_id":     AnthropicClientID,
+		"refresh_token": refreshToken,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling refresh request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", AnthropicTokenURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("refresh token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]any
+		json.NewDecoder(resp.Body).Decode(&errBody)
+		return nil, fmt.Errorf("token refresh failed (status %d): %v", resp.StatusCode, errBody)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("parsing refresh response: %w", err)
+	}
+
+	return &tokenResp, nil
+}
+
+// TokenToCredential converts a token response to a credential
+func TokenToCredential(token *TokenResponse) *Credential {
+	return &Credential{
+		Type:         "oauth",
+		Provider:     "anthropic",
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		ExpiresAt:    time.Now().Unix() + int64(token.ExpiresIn),
+	}
+}

--- a/internal/auth/pkce.go
+++ b/internal/auth/pkce.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// GeneratePKCE generates a PKCE code verifier and its S256 challenge.
+// The verifier is a random 32-byte string (base64url-encoded to ~43 chars).
+// The challenge is the SHA256 hash of the verifier, also base64url-encoded.
+func GeneratePKCE() (verifier, challenge string, err error) {
+	// Generate 32 random bytes for the verifier
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", err
+	}
+
+	verifier = base64.RawURLEncoding.EncodeToString(b)
+
+	// Create S256 challenge: BASE64URL(SHA256(verifier))
+	h := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(h[:])
+
+	return verifier, challenge, nil
+}

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// OAuthTransport wraps an http.RoundTripper to inject OAuth bearer tokens
+type OAuthTransport struct {
+	base  http.RoundTripper
+	store *Store
+	mu    sync.RWMutex
+}
+
+// NewOAuthTransport creates a new OAuth transport wrapper
+func NewOAuthTransport(store *Store) *OAuthTransport {
+	return &OAuthTransport{
+		base:  http.DefaultTransport,
+		store: store,
+	}
+}
+
+// NewOAuthHTTPClient creates an HTTP client configured for OAuth authentication
+func NewOAuthHTTPClient(store *Store) *http.Client {
+	return &http.Client{
+		Transport: NewOAuthTransport(store),
+		Timeout:   5 * time.Minute,
+	}
+}
+
+// RoundTrip implements http.RoundTripper
+func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cred, err := t.store.GetCredential("anthropic")
+	if err != nil {
+		return nil, fmt.Errorf("getting credential: %w", err)
+	}
+
+	// Check if token needs refresh (with 60 second buffer)
+	if cred.ExpiresAt > 0 && time.Now().Unix() >= cred.ExpiresAt-60 {
+		t.mu.Lock()
+		// Double-check after acquiring lock
+		cred, err = t.store.GetCredential("anthropic")
+		if err != nil {
+			t.mu.Unlock()
+			return nil, fmt.Errorf("getting credential: %w", err)
+		}
+
+		if time.Now().Unix() >= cred.ExpiresAt-60 {
+			tokenResp, err := RefreshAccessToken(context.Background(), cred.RefreshToken)
+			if err != nil {
+				t.mu.Unlock()
+				return nil, fmt.Errorf("refreshing token: %w", err)
+			}
+
+			cred = TokenToCredential(tokenResp)
+			if err := t.store.SaveCredential(cred); err != nil {
+				t.mu.Unlock()
+				return nil, fmt.Errorf("saving refreshed credential: %w", err)
+			}
+		}
+		t.mu.Unlock()
+	}
+
+	// Clone the request to avoid modifying the original
+	clone := req.Clone(req.Context())
+
+	// Set Bearer auth and required headers
+	clone.Header.Set("Authorization", "Bearer "+cred.AccessToken)
+	clone.Header.Set("anthropic-beta", AnthropicBetaHeader)
+	clone.Header.Del("x-api-key")
+
+	return t.base.RoundTrip(clone)
+}

--- a/internal/codemode/executor.go
+++ b/internal/codemode/executor.go
@@ -203,7 +203,7 @@ func classifyExitCode(result ExecutionResult) error {
 	}
 }
 
-// autoCorrectImports runs goimports (via golang.org/x/tools/imports) on the file 
+// autoCorrectImports runs goimports (via golang.org/x/tools/imports) on the file
 // and returns a notification message listing added/removed packages.
 func autoCorrectImports(ctx context.Context, dir, filename string) string {
 	filePath := filepath.Join(dir, filename)

--- a/internal/codemode/executor_test.go
+++ b/internal/codemode/executor_test.go
@@ -524,7 +524,6 @@ func Run(ctx context.Context) error {
 	}
 }
 
-
 func TestExecuteCode_AutoCorrectImports(t *testing.T) {
 	// Only run this test if goimports is installed
 	ctx := context.Background()
@@ -557,7 +556,7 @@ func Run(ctx context.Context) error {
 	if !strings.Contains(result.Output, "Added: fmt") {
 		t.Errorf("Output = %q, want to contain 'Added: fmt'", result.Output)
 	}
-	
+
 	if !strings.Contains(result.Output, "Imports corrected") {
 		t.Errorf("Output = %q, want to contain program output 'Imports corrected'", result.Output)
 	}

--- a/internal/codemode/tool_test.go
+++ b/internal/codemode/tool_test.go
@@ -52,7 +52,7 @@ func Run(ctx context.Context) error {
 			},
 			wantOutputSub: "syntax error",
 		},
-				{
+		{
 			name: "compilation error - undefined variable",
 			input: ExecuteGoCodeInput{
 				Code: `package main

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,8 @@ type Model struct {
 	ID                   string              `json:"id" yaml:"id" validate:"required"`
 	Type                 string              `json:"type" yaml:"type" validate:"required,oneof=openai anthropic gemini responses groq cerebras openrouter"`
 	BaseUrl              string              `json:"base_url" yaml:"base_url" validate:"omitempty,https_url|http_url"`
-	ApiKeyEnv            string              `json:"api_key_env" yaml:"api_key_env" validate:"required"`
+	ApiKeyEnv            string              `json:"api_key_env" yaml:"api_key_env" validate:"required_unless=AuthMethod oauth"`
+	AuthMethod           string              `json:"auth_method" yaml:"auth_method" validate:"omitempty,oneof=apikey oauth"`
 	ContextWindow        uint32              `json:"context_window" yaml:"context_window" validate:"omitempty,gt=0"`
 	MaxOutput            uint32              `json:"max_output" yaml:"max_output" validate:"omitempty,gt=0"`
 	InputCostPerMillion  float64             `json:"input_cost_per_million" yaml:"input_cost_per_million"`

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -223,6 +223,22 @@ func (c *RawConfig) Validate() error {
 		}
 	}
 
+	// Validate auth_method and api_key_env for each model
+	for _, m := range c.Models {
+		if err := validateModelAuth(m); err != nil {
+			return fmt.Errorf("model '%s': %w", m.Ref, err)
+		}
+	}
+
+	return nil
+}
+
+// validateModelAuth validates auth_method constraints
+func validateModelAuth(m ModelConfig) error {
+	// oauth is only valid for anthropic
+	if strings.ToLower(m.AuthMethod) == "oauth" && strings.ToLower(m.Type) != "anthropic" {
+		return fmt.Errorf("auth_method 'oauth' is only supported for anthropic provider")
+	}
 	return nil
 }
 

--- a/schema/cpe-config-schema.json
+++ b/schema/cpe-config-schema.json
@@ -13,6 +13,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "maxTimeout": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -99,6 +102,9 @@
           "type": "string"
         },
         "api_key_env": {
+          "type": "string"
+        },
+        "auth_method": {
           "type": "string"
         },
         "context_window": {


### PR DESCRIPTION
## Summary

Adds OAuth authentication support for Anthropic, allowing users to authenticate with their Claude Pro/Max subscription instead of API keys. This enables using subscription credits directly.

Closes #109

## Changes

- Add `internal/auth/` package with PKCE flow, token storage, and OAuth transport
- Add `cpe auth login anthropic`, `cpe auth logout anthropic`, and `cpe auth status` commands  
- Add `auth_method: oauth` config option for Anthropic models
- Prepend Claude Code identifier to system prompt (required by Anthropic for OAuth token validation)

## Usage

```bash
# Login with OAuth
cpe auth login anthropic

# Configure model to use OAuth
models:
  - ref: opus
    type: anthropic
    auth_method: oauth  # Use OAuth instead of api_key_env
    # ...
```