### PR TITLE
feat: Add Agent Skills support to system prompt

### DIFF
--- a/examples/agent_instructions.prompt
+++ b/examples/agent_instructions.prompt
@@ -1,6 +1,6 @@
 You are {{if .Model.DisplayName}}{{.Model.DisplayName}}{{else}}an AI{{end}} that is embedded in a command line interface tool called CPE (Chat-based Programming Editor), and you are superhuman AI agent designed to assist users with a wide range of tasks directly within their terminal, on the user's computer.
 {{- if and .CodeMode .CodeMode.Enabled }}
-You have access to a single tool: `execute_go_code`. This tool compiles and runs Go code you generate. The tool description contains the available functions and types generated from MCP tools.
+In addition to the general tools, you have access to a special tool: `execute_go_code`. This tool compiles and runs Go code you generate. The tool description may contain the available functions and types generated from connecting external tools tools to the `execute_go_code` so that you may call tools as code, in addition to the standard library from Golang.
 {{- end }}
 
 # About you
@@ -19,13 +19,12 @@ You also have certain CLIs installed on the user's system that can assist you du
 
 - `ripgrep`: The CLI `rg` (ripgrep) is a faster version of `grep`, written in rust for blazing speed. You should always prefer to use ripgrep over grep for all use cases, including in scripts.
 - `gh` (Github CLI) - The CLI `gh` can be used to gather context and take action on behalf of the user in Github via the cli.
-- `ast-grep`: When editing text files, `ast-grep` can be used to query, extract, and rewrite portions of the file. You should use this over the `text_edit` tool when simple find and replace can't be used.
 - `fzf`: To fuzzy search across files, you have the `fzf` cli installed.
 
 {{- if and .CodeMode .CodeMode.Enabled }}
 # Code Mode
 
-You are a **Go code generation agent**. You accomplish tasks by writing and executing Go programs that call MCP tool functions, run shell commands, process files, and interact with the system.
+You are a general purpose, helpful AI agent that **generates Golang code** to accomplish tasks by writing and executing Go programs that may call tool functions, run shell commands, process files, and interact with the system.
 
 ## Execution model
 
@@ -163,7 +162,7 @@ func readLines(path string, start, count int) ([]string, error) {
     file, err := os.Open(path)
     if err != nil { return nil, err }
     defer file.Close()
-    
+
     var lines []string
     scanner := bufio.NewScanner(file)
     for i := 1; scanner.Scan(); i++ {
@@ -293,6 +292,11 @@ The `type` is what type of change, which can be something like `feat`, `doc`, `b
 **Only** generate a commit message, do not commit without the user's approval.
 
 **IMPORTANT**: DO NOT USE LISTICLES (BULLET POINTS OR NUMBERED) LISTS IN COMMIT BODY, UNLESS EXPLICITLY ASKED FOR BY THE USER.
+**IMPORTANT**: Always describe **whatand why**, not how.
+
+## Searching and Understanding external libraries
+
+You may encounter external libraries/packages/modules when working on a codebase. In order to be effective when developing code in a codebase that uses external code, you must first understand the referenced external code. Since you are a superhuman AI, you may already have knowledge about the external code, but if you do not, then you should first understand the external library more. As an example, you may use `go doc` command to read the documentation of types/functions/methods or even entire packages, and do a grep-like search for examples in the downloaded modules. For javascript/typescript, you may perform a search in `node_modules`. Use your understanding of different programming stacks to best figure out the way to seek out external code docs and understand how the external code is used in the codebase. As a fallback, perform a search.
 
 # Tone and style
 
@@ -367,18 +371,41 @@ assistant: In `src/foo.c`
 ```
 {{- end }}
 
-{{if fileExists "AGENTS.md" -}}
 # AGENTS.md
 
 The AGENTS.md file is used to store the user's preferences, knowledge, and context that is helpful, such that the user's doesn't need to specify at the start of every new conversation with you. As such, consult the AGENTS.md file before starting on a task.
 
-````markdown
-{{includeFile "AGENTS.md"}}
-````
+AGENTS.md files may be found in the current directory, or in subdirectory. If found in a subdirectory, that AGENTS.md file specifically pertains to the contents of owning subdirectory.
 
-## Updating AGENTS.md
+If the user defines a preference, tells you to remember something, or you found something that you would like to remember, then you should add it to the AGENTS.md file. If there are multiple AGENTS.md files, such as in different subdirectories, make sure to update the correct one.
 
-If the user defines a preference, tells you to remember something, or you found something that you would like to remember, then you should add it to the AGENTS.md file.
-{{- end }}
+{{exec "find . -name AGENTS.md"}}
 
-You are now being connected to the user.
+# Skills
+
+Skills are reusable modules of instructions, scripts, and resources that extend your capabilities for specialized tasks. They follow the Agent Skills specification (agentskills.io).
+
+{{ skills "./skills" "~/.cpe/skills" "/Users/shashankpachava/dev/anthropic-skills/skills" }}
+
+When skills are available, you will see them listed above in XML format with their name, description, and path. To use a skill:
+
+1. Read the skill's SKILL.md file at the indicated path to load the full instructions
+2. Follow the instructions and use any scripts or references provided in the skill directory
+3. Skills may contain subdirectories like `scripts/`, `references/`, and `assets/` with additional resources
+
+Only load a skill's full instructions when the task is relevant to that skill's description.
+
+# Reminders
+
+**IMPORTANT:** if one or more relevant AGENTS.md file exists, you **MUST** read it first
+{{if and .CodeMode .CodeMode.Enabled -}}
+**IMPORTANT:** always keep the principles of code mode in mind
+**IMPORTANT:** be careful with backticks in strings, follow the guidance I outlined
+{{- end}}
+**IMPORTANT:** when generating a commit message, always adhere to the commit message guidelines. Keep it concise. Always describe "what" and "why", not "how"
+**IMPORTANT:** if skills are available, read the full SKILL.md before performing a task relevant to that skill
+
+
+---
+
+You are now being connected to the user. Go forth and be maximally useful, helpful, collaborative, all the things that make superhuman AI so great. Godspeed.

--- a/internal/agent/template.go
+++ b/internal/agent/template.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/spachava753/cpe/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 type TemplateData struct {
@@ -39,6 +42,7 @@ func createTemplateFuncMap() template.FuncMap {
 	fm["fileExists"] = fileExists
 	fm["includeFile"] = includeFile
 	fm["exec"] = execCommand
+	fm["skills"] = skills
 	return fm
 }
 
@@ -66,3 +70,141 @@ func execCommand(command string) string {
 	}
 	return strings.TrimSpace(string(output))
 }
+
+// SkillMetadata represents the YAML frontmatter of a SKILL.md file
+type SkillMetadata struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// Skill represents a parsed skill with its metadata and path
+type Skill struct {
+	Name        string
+	Description string
+	Path        string
+}
+
+// skills scans the provided directories for valid skill folders and returns
+// XML-formatted skill metadata for inclusion in the system prompt.
+// Each skill folder must contain a SKILL.md file with valid YAML frontmatter.
+func skills(paths ...string) string {
+	var allSkills []Skill
+
+	for _, basePath := range paths {
+		// Expand home directory
+		if strings.HasPrefix(basePath, "~/") {
+			home, err := os.UserHomeDir()
+			if err == nil {
+				basePath = filepath.Join(home, basePath[2:])
+			}
+		}
+
+		// Check if path exists
+		info, err := os.Stat(basePath)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+
+		// Read all entries in the skills directory
+		entries, err := os.ReadDir(basePath)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			skillDir := filepath.Join(basePath, entry.Name())
+			skillMdPath := filepath.Join(skillDir, "SKILL.md")
+
+			// Check if SKILL.md exists
+			if _, err := os.Stat(skillMdPath); err != nil {
+				continue
+			}
+
+			// Parse the skill
+			skill, err := parseSkill(skillMdPath, skillDir)
+			if err != nil {
+				continue
+			}
+
+			allSkills = append(allSkills, skill)
+		}
+	}
+
+	if len(allSkills) == 0 {
+		return ""
+	}
+
+	// Build XML output
+	var buf bytes.Buffer
+	buf.WriteString("<skills>\n")
+	for _, s := range allSkills {
+		buf.WriteString(fmt.Sprintf("  <skill name=%q>\n", s.Name))
+		buf.WriteString(fmt.Sprintf("    <description>%s</description>\n", s.Description))
+		buf.WriteString(fmt.Sprintf("    <path>%s</path>\n", s.Path))
+		buf.WriteString("  </skill>\n")
+	}
+	buf.WriteString("</skills>")
+
+	return buf.String()
+}
+
+// parseSkill reads a SKILL.md file and extracts the metadata
+func parseSkill(skillMdPath, skillDir string) (Skill, error) {
+	content, err := os.ReadFile(skillMdPath)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	// Extract YAML frontmatter
+	frontmatter, err := extractFrontmatter(string(content))
+	if err != nil {
+		return Skill{}, err
+	}
+
+	var meta SkillMetadata
+	if err := yaml.Unmarshal([]byte(frontmatter), &meta); err != nil {
+		return Skill{}, err
+	}
+
+	// Validate required fields
+	if meta.Name == "" || meta.Description == "" {
+		return Skill{}, fmt.Errorf("skill missing required name or description")
+	}
+
+	// Validate skill name format (lowercase alphanumeric with hyphens)
+	if !isValidSkillName(meta.Name) {
+		return Skill{}, fmt.Errorf("invalid skill name: %s", meta.Name)
+	}
+
+	return Skill{
+		Name:        meta.Name,
+		Description: meta.Description,
+		Path:        skillDir,
+	}, nil
+}
+
+// extractFrontmatter extracts YAML frontmatter from markdown content
+func extractFrontmatter(content string) (string, error) {
+	// Match YAML frontmatter between --- delimiters
+	re := regexp.MustCompile(`(?s)^---\r?\n(.+?)\r?\n---`)
+	matches := re.FindStringSubmatch(content)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("no frontmatter found")
+	}
+	return matches[1], nil
+}
+
+// isValidSkillName checks if the skill name follows the spec
+// (lowercase letters, numbers, and hyphens only, max 64 chars)
+func isValidSkillName(name string) bool {
+	if len(name) > 64 || len(name) == 0 {
+		return false
+	}
+	re := regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	return re.MatchString(name)
+}
+

--- a/internal/agent/template_test.go
+++ b/internal/agent/template_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -90,4 +91,301 @@ func TestExecCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a valid skill directory
+	validSkillDir := filepath.Join(tmpDir, "pdf-processing")
+	if err := os.MkdirAll(validSkillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	validSkillMd := `---
+name: pdf-processing
+description: Extract text and tables from PDF files.
+license: MIT
+---
+
+# PDF Processing Skill
+
+This skill helps with PDF operations.
+`
+	if err := os.WriteFile(filepath.Join(validSkillDir, "SKILL.md"), []byte(validSkillMd), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another valid skill
+	codeReviewDir := filepath.Join(tmpDir, "code-review")
+	if err := os.MkdirAll(codeReviewDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	codeReviewMd := `---
+name: code-review
+description: Performs code reviews with focus on security.
+---
+# Code Review Skill
+`
+	if err := os.WriteFile(filepath.Join(codeReviewDir, "SKILL.md"), []byte(codeReviewMd), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an invalid skill (missing name)
+	invalidSkillDir := filepath.Join(tmpDir, "invalid-skill")
+	if err := os.MkdirAll(invalidSkillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	invalidSkillMd := `---
+description: Missing name field
+---
+# Invalid
+`
+	if err := os.WriteFile(filepath.Join(invalidSkillDir, "SKILL.md"), []byte(invalidSkillMd), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory without SKILL.md
+	noSkillDir := filepath.Join(tmpDir, "not-a-skill")
+	if err := os.MkdirAll(noSkillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("single valid skills directory", func(t *testing.T) {
+		result := skills(tmpDir)
+		if !strings.Contains(result, "<skills>") {
+			t.Error("expected <skills> tag in output")
+		}
+		if !strings.Contains(result, `<skill name="pdf-processing">`) {
+			t.Error("expected pdf-processing skill in output")
+		}
+		if !strings.Contains(result, `<skill name="code-review">`) {
+			t.Error("expected code-review skill in output")
+		}
+		if strings.Contains(result, "invalid-skill") {
+			t.Error("invalid skill should not be in output")
+		}
+		if strings.Contains(result, "not-a-skill") {
+			t.Error("directory without SKILL.md should not be in output")
+		}
+	})
+
+	t.Run("non-existent directory", func(t *testing.T) {
+		result := skills("/nonexistent/path")
+		if result != "" {
+			t.Errorf("expected empty string for non-existent path, got %q", result)
+		}
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		emptyDir := filepath.Join(tmpDir, "empty")
+		if err := os.MkdirAll(emptyDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		result := skills(emptyDir)
+		if result != "" {
+			t.Errorf("expected empty string for empty directory, got %q", result)
+		}
+	})
+
+	t.Run("multiple directories", func(t *testing.T) {
+		anotherDir := filepath.Join(tmpDir, "another")
+		if err := os.MkdirAll(filepath.Join(anotherDir, "my-skill"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		mySkillMd := `---
+name: my-skill
+description: Another skill.
+---
+# My Skill
+`
+		if err := os.WriteFile(filepath.Join(anotherDir, "my-skill", "SKILL.md"), []byte(mySkillMd), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := skills(tmpDir, anotherDir)
+		if !strings.Contains(result, `<skill name="pdf-processing">`) {
+			t.Error("expected pdf-processing skill in output")
+		}
+		if !strings.Contains(result, `<skill name="my-skill">`) {
+			t.Error("expected my-skill skill in output")
+		}
+	})
+}
+
+func TestIsValidSkillName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"simple lowercase", "myskill", true},
+		{"with hyphen", "my-skill", true},
+		{"with numbers", "skill123", true},
+		{"complex valid", "my-skill-v2", true},
+		{"uppercase", "MySkill", false},
+		{"underscore", "my_skill", false},
+		{"starts with hyphen", "-skill", false},
+		{"ends with hyphen", "skill-", false},
+		{"double hyphen", "my--skill", false},
+		{"empty", "", false},
+		{"too long", strings.Repeat("a", 65), false},
+		{"max length", strings.Repeat("a", 64), true},
+		{"special chars", "skill@name", false},
+		{"spaces", "my skill", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidSkillName(tt.input)
+			if result != tt.expected {
+				t.Errorf("isValidSkillName(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractFrontmatter(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "valid frontmatter",
+			content: `---
+name: test
+description: A test skill
+---
+# Content
+`,
+			expected: "name: test\ndescription: A test skill",
+		},
+		{
+			name:        "no frontmatter",
+			content:     "# Just markdown",
+			expectError: true,
+		},
+		{
+			name:        "empty content",
+			content:     "",
+			expectError: true,
+		},
+		{
+			name: "frontmatter with extra fields",
+			content: `---
+name: skill
+description: desc
+license: MIT
+metadata:
+  author: test
+---
+Body
+`,
+			expected: "name: skill\ndescription: desc\nlicense: MIT\nmetadata:\n  author: test",
+		},
+		{
+			name:     "frontmatter with CRLF line endings",
+			content:  "---\r\nname: skill\r\ndescription: desc\r\n---\r\nBody",
+			expected: "name: skill\r\ndescription: desc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := extractFrontmatter(tt.content)
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("extractFrontmatter() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+
+func TestParseSkill(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("valid skill", func(t *testing.T) {
+		skillDir := filepath.Join(tmpDir, "valid-skill")
+		if err := os.MkdirAll(skillDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		skillMd := `---
+name: valid-skill
+description: A valid skill for testing.
+---
+# Valid Skill
+`
+		skillPath := filepath.Join(skillDir, "SKILL.md")
+		if err := os.WriteFile(skillPath, []byte(skillMd), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		skill, err := parseSkill(skillPath, skillDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if skill.Name != "valid-skill" {
+			t.Errorf("Name = %q, want %q", skill.Name, "valid-skill")
+		}
+		if skill.Description != "A valid skill for testing." {
+			t.Errorf("Description = %q, want %q", skill.Description, "A valid skill for testing.")
+		}
+		if skill.Path != skillDir {
+			t.Errorf("Path = %q, want %q", skill.Path, skillDir)
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		skillDir := filepath.Join(tmpDir, "no-name")
+		if err := os.MkdirAll(skillDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		skillMd := `---
+description: Missing name field.
+---
+# No Name
+`
+		skillPath := filepath.Join(skillDir, "SKILL.md")
+		if err := os.WriteFile(skillPath, []byte(skillMd), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := parseSkill(skillPath, skillDir)
+		if err == nil {
+			t.Error("expected error for missing name")
+		}
+	})
+
+	t.Run("invalid name format", func(t *testing.T) {
+		skillDir := filepath.Join(tmpDir, "bad-name")
+		if err := os.MkdirAll(skillDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		skillMd := `---
+name: Invalid_Name
+description: Has invalid name.
+---
+# Bad Name
+`
+		skillPath := filepath.Join(skillDir, "SKILL.md")
+		if err := os.WriteFile(skillPath, []byte(skillMd), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := parseSkill(skillPath, skillDir)
+		if err == nil {
+			t.Error("expected error for invalid name format")
+		}
+	})
 }


### PR DESCRIPTION
This PR adds support for the [Agent Skills specification](https://agentskills.io) to CPE's system prompt templating.

## What's New

A new `skills` template function that scans directories for skill folders and injects their metadata into the system prompt. Skills are reusable modules of instructions, scripts, and resources that extend the agent's capabilities for specialized tasks.

Example usage in a system prompt template:

```
{{ skills "./skills" "~/.cpe/skills" }}
```

This renders XML-formatted skill metadata that makes the agent aware of available skills:

```xml
<skills>
  <skill name="pdf-processing">
    <description>Extract text and tables from PDF files.</description>
    <path>/path/to/pdf-processing</path>
  </skill>
</skills>
```

## Why

Skills provide a standardized way to package domain-specific knowledge into self-contained, shareable modules. Unlike AGENTS.md files which are project-specific, skills can be reused across projects and shared with others. The agent loads full skill instructions on-demand only when relevant, reducing context usage.

Closes #124