### PR TITLE
fix(auth): allow OAuth transport to use patched HTTP client

### DIFF
--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -20,7 +20,7 @@ const (
 	AnthropicTokenURL    = "https://console.anthropic.com/v1/oauth/token"
 	AnthropicRedirectURI = "https://console.anthropic.com/oauth/code/callback"
 	AnthropicScopes      = "org:create_api_key user:profile user:inference"
-	AnthropicBetaHeader  = "oauth-2025-04-20,claude-code-20250219"
+	AnthropicAuthBetaHeader  = "oauth-2025-04-20,claude-code-20250219"
 )
 
 // TokenResponse represents the OAuth token response from Anthropic


### PR DESCRIPTION
## Summary

Fixes #127 - OAuth authentication now properly uses patch_request configurations.

## Problem

When using OAuth authentication with Anthropic, the `patch_request` configuration (custom headers and JSON patches) was silently ignored. This happened because `NewOAuthHTTPClient` always used `http.DefaultTransport` as its base transport, with no way to inject the PatchTransport.

## Solution

- Modified `NewOAuthTransport` and `NewOAuthHTTPClient` to accept an optional base transport parameter
- Updated the generator to build the correct transport chain: PatchTransport → OAuthTransport → DefaultTransport
- OAuthTransport merges its required OAuth beta headers with any headers already set via patch_request config

## Testing

Added tests in `internal/auth/transport_test.go` verifying the transport chain works correctly with both custom headers and JSON patches when using OAuth.