### PR TITLE
Fix silent failures when loading skills with front matter errors

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -297,7 +297,7 @@ func createSubagentExecutor(cfgPath string, outputSchema *jsonschema.Schema, sub
 
 			systemPrompt, err = agent.SystemPromptTemplate(string(contents), agent.TemplateData{
 				Config: effectiveConfig,
-			})
+			}, os.Stderr)
 			if err != nil {
 				return "", fmt.Errorf("failed to prepare system prompt: %w", err)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func executeRootCommand(ctx context.Context, args []string) error {
 
 		systemPrompt, err = agent.SystemPromptTemplate(string(contents), agent.TemplateData{
 			Config: effectiveConfig,
-		})
+		}, os.Stderr)
 		if err != nil {
 			return fmt.Errorf("failed to prepare system prompt: %w", err)
 		}

--- a/internal/commands/model.go
+++ b/internal/commands/model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"os"
 
 	"github.com/spachava753/cpe/internal/agent"
 	"github.com/spachava753/cpe/internal/config"
@@ -125,7 +126,7 @@ func ModelSystemPrompt(opts ModelSystemPromptOptions) error {
 
 	systemPrompt, err := agent.SystemPromptTemplate(string(contents), agent.TemplateData{
 		Config: templateConfig,
-	})
+	}, os.Stderr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Skills with YAML syntax errors in their SKILL.md files were silently ignored, making it difficult to diagnose why a skill wasn't loading.

## Changes
- Added `io.Writer` parameter to `SystemPromptTemplate` and related functions for configurable warning output
- Print warnings to stderr when skill parsing fails
- Added test for YAML syntax error reporting

## Testing
- All agent package tests pass
- Added `TestSkillsReportsYAMLSyntaxErrors` to verify warnings are printed

Fixes #133