### PR TITLE
fix(cli): remove vestigial --no-stream flag

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -308,7 +308,6 @@ func createSubagentExecutor(cfgPath string, outputSchema *jsonschema.Schema, sub
 			effectiveConfig.Model,
 			systemPrompt,
 			effectiveConfig.Timeout,
-			effectiveConfig.NoStream,
 			true, // disablePrinting - MCP server mode must not write to stdout
 			effectiveConfig.MCPServers,
 			effectiveConfig.CodeMode,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,6 @@ var (
 	continueID       string
 	incognitoMode    bool
 	timeout          string
-	disableStreaming bool
 	skipStdin        bool
 	configPath       string
 
@@ -90,7 +89,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&continueID, "continue", "c", "", "Continue from a specific conversation ID")
 	rootCmd.PersistentFlags().BoolVarP(&incognitoMode, "incognito", "G", false, "Run in incognito mode (do not save conversations to storage)")
 	rootCmd.PersistentFlags().StringVarP(&timeout, "timeout", "", "", "Specify request timeout duration (e.g. '5m', '30s')")
-	rootCmd.PersistentFlags().BoolVar(&disableStreaming, "no-stream", false, "Disable streaming output (show complete response after generation)")
 	rootCmd.PersistentFlags().BoolVar(&skipStdin, "skip-stdin", false, "Skip reading from stdin (useful in scripts)")
 	rootCmd.PersistentFlags().StringVar(&configPath, "config", "", "Path to unified configuration file (default: ./cpe.yaml, ~/.config/cpe/cpe.yaml)")
 
@@ -106,12 +104,10 @@ func executeRootCommand(ctx context.Context, args []string) error {
 	}
 
 	// Resolve effective config with runtime options
-	noStream := disableStreaming
 	effectiveConfig, err := config.ResolveConfig(configPath, config.RuntimeOptions{
 		ModelRef:  model,
 		GenParams: &genParams,
 		Timeout:   timeout,
-		NoStream:  &noStream,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to resolve configuration: %w", err)
@@ -149,7 +145,6 @@ func executeRootCommand(ctx context.Context, args []string) error {
 		effectiveConfig.Model,
 		systemPrompt,
 		effectiveConfig.Timeout,
-		effectiveConfig.NoStream,
 		false, // disablePrinting - keep response printing for interactive use
 		effectiveConfig.MCPServers,
 		effectiveConfig.CodeMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,8 +111,6 @@ type Defaults struct {
 	// Request timeout
 	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 
-	// Disable streaming globally
-	NoStream bool `yaml:"noStream,omitempty" json:"noStream,omitempty"`
 
 	// Code mode configuration
 	CodeMode *CodeModeConfig `yaml:"codeMode,omitempty" json:"codeMode,omitempty"`
@@ -159,8 +157,6 @@ type Config struct {
 	// Effective timeout
 	Timeout time.Duration
 
-	// Whether streaming is disabled
-	NoStream bool
 
 	// Effective code mode configuration
 	CodeMode *CodeModeConfig
@@ -177,6 +173,4 @@ type RuntimeOptions struct {
 	// Timeout override (from --timeout)
 	Timeout string
 
-	// Streaming override (from --no-stream)
-	NoStream *bool
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -354,13 +354,6 @@ func ResolveConfig(configPath string, opts RuntimeOptions) (*Config, error) {
 		timeout = parsedTimeout
 	}
 
-	// Resolve streaming settings
-	var noStream bool
-	if opts.NoStream != nil {
-		noStream = *opts.NoStream
-	} else {
-		noStream = rawCfg.Defaults.NoStream
-	}
 
 	// Resolve code mode configuration with override behavior (not merge)
 	// Model-level completely replaces defaults
@@ -377,7 +370,6 @@ func ResolveConfig(configPath string, opts RuntimeOptions) (*Config, error) {
 		SystemPromptPath:   systemPromptPath,
 		GenerationDefaults: genParams,
 		Timeout:            timeout,
-		NoStream:           noStream,
 		CodeMode:           codeMode,
 	}, nil
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -547,12 +547,6 @@ func resolveConfigFromRaw(rawCfg *RawConfig, opts RuntimeOptions) (*Config, erro
 		timeout = parsedTimeout
 	}
 
-	var noStream bool
-	if opts.NoStream != nil {
-		noStream = *opts.NoStream
-	} else {
-		noStream = rawCfg.Defaults.NoStream
-	}
 
 	// Resolve code mode configuration with override behavior (not merge)
 	var codeMode *CodeModeConfig
@@ -568,7 +562,6 @@ func resolveConfigFromRaw(rawCfg *RawConfig, opts RuntimeOptions) (*Config, erro
 		SystemPromptPath:   systemPromptPath,
 		GenerationDefaults: genParams,
 		Timeout:            timeout,
-		NoStream:           noStream,
 		CodeMode:           codeMode,
 	}, nil
 }


### PR DESCRIPTION
## Summary
Removes the vestigial `--no-stream` flag and all associated streaming configuration that remained after the streaming printer was removed.

## Changes
- Remove `--no-stream` CLI flag from `cmd/root.go`
- Remove `disableStreaming` parameter from `CreateToolCapableGenerator`
- Remove `NoStream` fields from config types
- Remove conditional `StreamingAdapter` logic in generator.go

## Testing
- `go build ./...` passes
- `go test ./internal/config/...` passes

Closes #152