### PR TITLE
feat(config): add models from models.dev registry via CLI

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spachava753/cpe/internal/commands"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage CPE configuration",
+}
+
+var configAddRef string
+
+var configAddCmd = &cobra.Command{
+	Use:   "add <provider>/<model-id>",
+	Short: "Add a model from the models.dev registry to your configuration",
+	Long: `Add a model from the models.dev registry to your CPE configuration.
+
+The command fetches model information from https://models.dev/api.json and adds
+the model to your configuration file with appropriate defaults.
+
+Examples:
+  cpe config add anthropic/claude-sonnet-4-20250514
+  cpe config add openai/gpt-4o
+  cpe config add google/gemini-2.5-pro
+  cpe config add anthropic/claude-sonnet-4-20250514 --ref sonnet`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return commands.ConfigAdd(cmd.Context(), commands.ConfigAddOptions{
+			ModelSpec:  args[0],
+			ConfigPath: configPath,
+			Ref:        configAddRef,
+			Writer:     os.Stdout,
+		})
+	},
+}
+
+var configRemoveCmd = &cobra.Command{
+	Use:   "remove <ref>",
+	Short: "Remove a model from your configuration by ref",
+	Long:  "Remove a model from your CPE configuration file by its reference name.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return commands.ConfigRemove(cmd.Context(), commands.ConfigRemoveOptions{
+			Ref:        args[0],
+			ConfigPath: configPath,
+			Writer:     os.Stdout,
+		})
+	},
+}
+
+func init() {
+	configAddCmd.Flags().StringVar(&configAddRef, "ref", "", "Custom reference name for the model (defaults to model ID)")
+	configCmd.AddCommand(configAddCmd)
+	configCmd.AddCommand(configRemoveCmd)
+	rootCmd.AddCommand(configCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,15 +24,15 @@ import (
 var DefaultModel = os.Getenv("CPE_MODEL")
 
 var (
-	model            string
-	customURL        string
-	input            []string
-	newConversation  bool
-	continueID       string
-	incognitoMode    bool
-	timeout          string
-	skipStdin        bool
-	configPath       string
+	model           string
+	customURL       string
+	input           []string
+	newConversation bool
+	continueID      string
+	incognitoMode   bool
+	timeout         string
+	skipStdin       bool
+	configPath      string
 
 	genParams gai.GenOpts
 )

--- a/docs/specs/code_mode_token_comparison_test.go
+++ b/docs/specs/code_mode_token_comparison_test.go
@@ -1,8 +1,8 @@
 package specs
 
 import (
-	_ "embed"
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
 	"testing"
@@ -20,12 +20,12 @@ import (
 // using the examples from docs/specs/code_mode.md.
 //
 // This test requires ANTHROPIC_API_KEY environment variable to be set.
+//
 //go:embed testdata/virtual_tool_sample_code.txt
 var virtualToolSampleCode string
 
 //go:embed testdata/virtual_tool_call_example.txt
 var virtualToolCallExample string
-
 
 func TestCodeModeTokenComparison(t *testing.T) {
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spachava753/cpe/internal/config"
+)
+
+// ConfigAddOptions contains options for the config add command
+type ConfigAddOptions struct {
+	ModelSpec  string    // provider/model-id format
+	ConfigPath string    // path to config file (empty for default)
+	Ref        string    // optional custom ref name
+	Writer     io.Writer // output writer
+}
+
+// ConfigAdd adds a model from the models.dev registry to the config
+func ConfigAdd(ctx context.Context, opts ConfigAddOptions) error {
+	// Parse provider/model-id
+	parts := strings.SplitN(opts.ModelSpec, "/", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid model spec %q: expected format <provider>/<model-id>", opts.ModelSpec)
+	}
+	providerID, modelID := parts[0], parts[1]
+
+	// Fetch models.dev registry
+	registry, err := config.FetchModelsDevRegistry(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching models.dev registry: %w", err)
+	}
+
+	// Look up provider and model
+	provider, model, err := config.LookupRegistryModel(registry, providerID, modelID)
+	if err != nil {
+		return err
+	}
+
+	// Build model config from registry data
+	modelCfg, err := config.BuildModelFromRegistry(provider, model, opts.Ref)
+	if err != nil {
+		return err
+	}
+
+	// Determine config path
+	configPath := opts.ConfigPath
+	if configPath == "" {
+		configPath = config.FindDefaultConfigPath()
+	}
+
+	// Load or create config
+	rawCfg, err := config.LoadOrCreateRawConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	// Add the model
+	if err := rawCfg.AddModel(*modelCfg); err != nil {
+		return err
+	}
+
+	// Write back to file
+	if err := config.WriteRawConfig(configPath, rawCfg); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	fmt.Fprintf(opts.Writer, "Added model %s/%s as %q to %s\n", providerID, modelID, modelCfg.Ref, configPath)
+	return nil
+}
+
+// ConfigRemoveOptions contains options for the config remove command
+type ConfigRemoveOptions struct {
+	Ref        string    // model ref to remove
+	ConfigPath string    // path to config file (empty for default)
+	Writer     io.Writer // output writer
+}
+
+// ConfigRemove removes a model from the config by ref
+func ConfigRemove(ctx context.Context, opts ConfigRemoveOptions) error {
+	// Determine config path
+	configPath := opts.ConfigPath
+	if configPath == "" {
+		configPath = config.FindDefaultConfigPath()
+	}
+
+	// Load config
+	rawCfg, err := config.LoadRawConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	// Remove the model
+	if err := rawCfg.RemoveModel(opts.Ref); err != nil {
+		return err
+	}
+
+	// Write back to file
+	if err := config.WriteRawConfig(configPath, rawCfg); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	fmt.Fprintf(opts.Writer, "Removed model %q from %s\n", opts.Ref, configPath)
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,13 +14,13 @@ type Model struct {
 	DisplayName          string              `json:"display_name" yaml:"display_name" validate:"required"`
 	ID                   string              `json:"id" yaml:"id" validate:"required"`
 	Type                 string              `json:"type" yaml:"type" validate:"required,oneof=openai anthropic gemini responses groq cerebras openrouter zai"`
-	BaseUrl              string              `json:"base_url" yaml:"base_url" validate:"omitempty,https_url|http_url"`
+	BaseUrl              string              `json:"base_url" yaml:"base_url,omitempty" validate:"omitempty,https_url|http_url"`
 	ApiKeyEnv            string              `json:"api_key_env" yaml:"api_key_env" validate:"required_unless=AuthMethod oauth"`
-	AuthMethod           string              `json:"auth_method" yaml:"auth_method" validate:"omitempty,oneof=apikey oauth"`
-	ContextWindow        uint32              `json:"context_window" yaml:"context_window" validate:"omitempty,gt=0"`
-	MaxOutput            uint32              `json:"max_output" yaml:"max_output" validate:"omitempty,gt=0"`
-	InputCostPerMillion  float64             `json:"input_cost_per_million" yaml:"input_cost_per_million"`
-	OutputCostPerMillion float64             `json:"output_cost_per_million" yaml:"output_cost_per_million"`
+	AuthMethod           string              `json:"auth_method" yaml:"auth_method,omitempty" validate:"omitempty,oneof=apikey oauth"`
+	ContextWindow        uint32              `json:"context_window" yaml:"context_window,omitempty" validate:"omitempty,gt=0"`
+	MaxOutput            uint32              `json:"max_output" yaml:"max_output,omitempty" validate:"omitempty,gt=0"`
+	InputCostPerMillion  float64             `json:"input_cost_per_million" yaml:"input_cost_per_million,omitempty"`
+	OutputCostPerMillion float64             `json:"output_cost_per_million" yaml:"output_cost_per_million,omitempty"`
 	PatchRequest         *PatchRequestConfig `json:"patchRequest,omitempty" yaml:"patchRequest,omitempty"`
 }
 
@@ -111,7 +111,6 @@ type Defaults struct {
 	// Request timeout
 	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 
-
 	// Code mode configuration
 	CodeMode *CodeModeConfig `yaml:"codeMode,omitempty" json:"codeMode,omitempty"`
 }
@@ -157,7 +156,6 @@ type Config struct {
 	// Effective timeout
 	Timeout time.Duration
 
-
 	// Effective code mode configuration
 	CodeMode *CodeModeConfig
 }
@@ -172,5 +170,4 @@ type RuntimeOptions struct {
 
 	// Timeout override (from --timeout)
 	Timeout string
-
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -354,7 +354,6 @@ func ResolveConfig(configPath string, opts RuntimeOptions) (*Config, error) {
 		timeout = parsedTimeout
 	}
 
-
 	// Resolve code mode configuration with override behavior (not merge)
 	// Model-level completely replaces defaults
 	var codeMode *CodeModeConfig

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -547,7 +547,6 @@ func resolveConfigFromRaw(rawCfg *RawConfig, opts RuntimeOptions) (*Config, erro
 		timeout = parsedTimeout
 	}
 
-
 	// Resolve code mode configuration with override behavior (not merge)
 	var codeMode *CodeModeConfig
 	if selectedModel.CodeMode != nil {

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ModelsDevAPI is the URL for the models.dev registry
+const ModelsDevAPI = "https://models.dev/api.json"
+
+// ModelsDevProvider represents a provider in the models.dev registry
+type ModelsDevProvider struct {
+	ID     string                    `json:"id"`
+	Name   string                    `json:"name"`
+	Env    []string                  `json:"env"`
+	API    string                    `json:"api,omitempty"`
+	Models map[string]ModelsDevModel `json:"models"`
+}
+
+// ModelsDevModel represents a model in the models.dev registry
+type ModelsDevModel struct {
+	ID       string          `json:"id"`
+	Name     string          `json:"name"`
+	Limit    *ModelsDevLimit `json:"limit,omitempty"`
+	Cost     *ModelsDevCost  `json:"cost,omitempty"`
+	ToolCall bool            `json:"tool_call"`
+}
+
+// ModelsDevLimit represents token limits for a model
+type ModelsDevLimit struct {
+	Context int `json:"context"`
+	Output  int `json:"output"`
+}
+
+// ModelsDevCost represents cost per million tokens
+type ModelsDevCost struct {
+	Input  float64 `json:"input"`
+	Output float64 `json:"output"`
+}
+
+// providerTypeMap maps models.dev provider IDs to CPE types
+var providerTypeMap = map[string]string{
+	"anthropic":           "anthropic",
+	"openai":              "openai",
+	"google":              "gemini",
+	"groq":                "groq",
+	"cerebras":            "cerebras",
+	"openrouter":          "openrouter",
+	"zai":                 "zai",
+	"zai-coding-plan":     "anthropic",
+	"minimax-coding-plan": "anthropic",
+}
+
+// SupportedRegistryProviders returns the list of supported provider IDs from models.dev
+func SupportedRegistryProviders() []string {
+	providers := make([]string, 0, len(providerTypeMap))
+	for p := range providerTypeMap {
+		providers = append(providers, p)
+	}
+	return providers
+}
+
+// FetchModelsDevRegistry fetches the models.dev registry
+func FetchModelsDevRegistry(ctx context.Context) (map[string]ModelsDevProvider, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", ModelsDevAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var registry map[string]ModelsDevProvider
+	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return registry, nil
+}
+
+// LookupRegistryModel looks up a provider and model in the registry
+func LookupRegistryModel(registry map[string]ModelsDevProvider, providerID, modelID string) (*ModelsDevProvider, *ModelsDevModel, error) {
+	provider, ok := registry[providerID]
+	if !ok {
+		return nil, nil, fmt.Errorf("provider %q not found in models.dev registry", providerID)
+	}
+
+	model, ok := provider.Models[modelID]
+	if !ok {
+		var available []string
+		for id := range provider.Models {
+			available = append(available, id)
+		}
+		return nil, nil, fmt.Errorf("model %q not found for provider %q. Available models: %v", modelID, providerID, available)
+	}
+
+	return &provider, &model, nil
+}
+
+// BuildModelFromRegistry creates a ModelConfig from registry data
+func BuildModelFromRegistry(provider *ModelsDevProvider, model *ModelsDevModel, ref string) (*ModelConfig, error) {
+	cpeType, ok := providerTypeMap[provider.ID]
+	if !ok {
+		supported := SupportedRegistryProviders()
+		return nil, fmt.Errorf("provider %q is not supported by CPE. Supported providers: %v", provider.ID, supported)
+	}
+
+	// Determine ref name if not provided
+	if ref == "" {
+		ref = sanitizeRef(model.ID)
+	}
+
+	// Determine API key env var
+	apiKeyEnv := ""
+	if len(provider.Env) > 0 {
+		apiKeyEnv = provider.Env[0]
+	}
+
+	cfg := &ModelConfig{
+		Model: Model{
+			Ref:         ref,
+			DisplayName: model.Name,
+			ID:          model.ID,
+			Type:        cpeType,
+			ApiKeyEnv:   apiKeyEnv,
+			BaseUrl:     provider.API,
+		},
+	}
+
+	if model.Limit != nil {
+		cfg.ContextWindow = uint32(model.Limit.Context)
+		cfg.MaxOutput = uint32(model.Limit.Output)
+	}
+	if model.Cost != nil {
+		cfg.InputCostPerMillion = model.Cost.Input
+		cfg.OutputCostPerMillion = model.Cost.Output
+	}
+
+	return cfg, nil
+}
+
+// sanitizeRef creates a reasonable ref from a model ID
+func sanitizeRef(modelID string) string {
+	ref := modelID
+	ref = strings.ReplaceAll(ref, "/", "-")
+	ref = strings.ReplaceAll(ref, ":", "-")
+	ref = strings.ReplaceAll(ref, "_", "-")
+
+	for strings.Contains(ref, "--") {
+		ref = strings.ReplaceAll(ref, "--", "-")
+	}
+
+	return strings.Trim(ref, "-")
+}

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FindDefaultConfigPath returns the default config path for the current platform
+func FindDefaultConfigPath() string {
+	// Check current directory first
+	if _, err := os.Stat("cpe.yaml"); err == nil {
+		return "cpe.yaml"
+	}
+	if _, err := os.Stat("cpe.yml"); err == nil {
+		return "cpe.yml"
+	}
+
+	// Fall back to user config directory (platform-specific)
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "cpe.yaml"
+	}
+	return filepath.Join(configDir, "cpe", "cpe.yaml")
+}
+
+// LoadOrCreateRawConfig loads an existing config or returns an empty one
+func LoadOrCreateRawConfig(path string) (*RawConfig, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &RawConfig{
+			Version: "1.0",
+			Models:  []ModelConfig{},
+		}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg RawConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// WriteRawConfig writes the config to a file
+func WriteRawConfig(path string, cfg *RawConfig) error {
+	// Ensure parent directory exists
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("creating config directory: %w", err)
+		}
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// AddModel adds a model to the config, checking for duplicate refs
+func (c *RawConfig) AddModel(model ModelConfig) error {
+	for _, m := range c.Models {
+		if m.Ref == model.Ref {
+			return fmt.Errorf("model with ref %q already exists in config", model.Ref)
+		}
+	}
+
+	c.Models = append(c.Models, model)
+
+	if c.Version == "" {
+		c.Version = "1.0"
+	}
+
+	return nil
+}
+
+// RemoveModel removes a model from the config by ref
+func (c *RawConfig) RemoveModel(ref string) error {
+	for i, m := range c.Models {
+		if m.Ref == ref {
+			c.Models = append(c.Models[:i], c.Models[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("model with ref %q not found in config", ref)
+}


### PR DESCRIPTION
## Summary

Implements the feature requested in #146 - adding models from the models.dev registry via CLI.

## Changes

### New Commands

- `cpe config add <provider>/<model-id>` - Add a model from models.dev registry
- `cpe config remove <ref>` - Remove a model by reference name

### Usage Examples

```bash
# Add models from registry
cpe config add anthropic/claude-sonnet-4-20250514
cpe config add anthropic/claude-sonnet-4-20250514 --ref sonnet
cpe config add google/gemini-2.5-pro --ref gemini
cpe config add zai-coding-plan/glm-4.7 --ref glm

# Remove a model
cpe config remove sonnet
```

### Supported Providers

| Provider | CPE Type | Notes |
|----------|----------|-------|
| anthropic | anthropic | |
| openai | openai | |
| google | gemini | |
| groq | groq | |
| cerebras | cerebras | |
| openrouter | openrouter | |
| zai | zai | Z.AI |
| zai-coding-plan | anthropic | Custom base URL |
| minimax-coding-plan | anthropic | Custom base URL |

### Code Organization

- `internal/config/registry.go` - models.dev API types, fetching, and model building
- `internal/config/writer.go` - Config file writing and modification
- `internal/commands/config.go` - Thin command handlers
- `cmd/config.go` - Cobra command definitions

Closes #146