### PR TITLE
refactor(mcp): remove redundant toolFilter field from ServerConfig

### DIFF
--- a/internal/commands/mcp.go
+++ b/internal/commands/mcp.go
@@ -186,17 +186,23 @@ func MCPListTools(ctx context.Context, opts MCPListToolsOptions) error {
 
 	markdownBuilder.WriteString(fmt.Sprintf("# %s\n\n", title))
 
-	toolFilter := serverConfig.ToolFilter
-	if toolFilter == "" {
-		toolFilter = "all"
+	// Infer filter mode from which list is populated
+	var filterMode string
+	switch {
+	case len(serverConfig.EnabledTools) > 0:
+		filterMode = "whitelist"
+	case len(serverConfig.DisabledTools) > 0:
+		filterMode = "blacklist"
+	default:
+		filterMode = "all"
 	}
 
-	markdownBuilder.WriteString("**Filter mode:** `" + toolFilter + "`")
+	markdownBuilder.WriteString("**Filter mode:** `" + filterMode + "`")
 
-	if toolFilter == "whitelist" && len(serverConfig.EnabledTools) > 0 {
+	if len(serverConfig.EnabledTools) > 0 {
 		markdownBuilder.WriteString(" | **Enabled tools:** `" + strings.Join(serverConfig.EnabledTools, "`, `") + "`")
 	}
-	if toolFilter == "blacklist" && len(serverConfig.DisabledTools) > 0 {
+	if len(serverConfig.DisabledTools) > 0 {
 		markdownBuilder.WriteString(" | **Disabled tools:** `" + strings.Join(serverConfig.DisabledTools, "`, `") + "`")
 	}
 

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -112,42 +112,48 @@ func TestServerConfigValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Invalid tool filter",
-			config: ServerConfig{
-				Type:       "stdio",
-				Command:    "editor-mcp",
-				ToolFilter: "greylist",
-			},
-			wantErr: true,
-		},
-		{
-			name: "Tool filter blacklist",
+			name: "Blacklist mode with DisabledTools",
 			config: ServerConfig{
 				Type:          "stdio",
 				Command:       "editor-mcp",
-				ToolFilter:    "blacklist",
 				DisabledTools: []string{"shell"},
 			},
 			wantErr: false,
 		},
 		{
-			name: "Tool filter whitelist",
+			name: "Whitelist mode with EnabledTools",
 			config: ServerConfig{
 				Type:         "stdio",
 				Command:      "editor-mcp",
-				ToolFilter:   "whitelist",
 				EnabledTools: []string{"shell"},
 			},
 			wantErr: false,
 		},
 		{
-			name: "Tool filter whitelist and blacklist",
+			name: "EnabledTools and DisabledTools mutually exclusive",
 			config: ServerConfig{
 				Type:          "stdio",
 				Command:       "editor-mcp",
-				ToolFilter:    "whitelist",
 				EnabledTools:  []string{"shell"},
 				DisabledTools: []string{"str_replace"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Empty EnabledTools rejected",
+			config: ServerConfig{
+				Type:         "stdio",
+				Command:      "editor-mcp",
+				EnabledTools: []string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Empty DisabledTools rejected",
+			config: ServerConfig{
+				Type:          "stdio",
+				Command:       "editor-mcp",
+				DisabledTools: []string{},
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## Summary

Removes the redundant `toolFilter` field from MCP server configuration. The filtering mode is now inferred from which list is populated:

- `enabledTools` present → whitelist mode
- `disabledTools` present → blacklist mode
- Neither present → allow all tools

## Changes

- Removed `ToolFilter` field from `ServerConfig` struct
- Updated `FilterMcpTools` to infer mode from list presence
- Added `min=1` validation to reject empty tool lists
- Updated tests

## Breaking Change

Existing configs using `toolFilter` will have it silently ignored. Users should remove the field from their configs.

Closes #156