### PR TITLE
fix(conversation): consistent formatting for execute_go_code in conversation print

### DIFF
--- a/internal/agent/codemode_format.go
+++ b/internal/agent/codemode_format.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spachava753/cpe/internal/codemode"
+)
+
+// ExecuteGoCodeFormatInput contains the parsed input from an execute_go_code tool call
+type ExecuteGoCodeFormatInput struct {
+	Code             string
+	ExecutionTimeout int
+}
+
+// ParseExecuteGoCodeToolCall attempts to parse a tool call JSON as an execute_go_code input.
+// Returns the parsed input and true if successful, or empty input and false otherwise.
+func ParseExecuteGoCodeToolCall(content string) (ExecuteGoCodeFormatInput, bool) {
+	// First try to parse as a ToolCallInput
+	var toolCall struct {
+		Name       string          `json:"name"`
+		Parameters json.RawMessage `json:"parameters"`
+	}
+	if err := json.Unmarshal([]byte(content), &toolCall); err != nil {
+		return ExecuteGoCodeFormatInput{}, false
+	}
+
+	if toolCall.Name != codemode.ExecuteGoCodeToolName {
+		return ExecuteGoCodeFormatInput{}, false
+	}
+
+	var input codemode.ExecuteGoCodeInput
+	if err := json.Unmarshal(toolCall.Parameters, &input); err != nil || input.Code == "" {
+		return ExecuteGoCodeFormatInput{}, false
+	}
+
+	return ExecuteGoCodeFormatInput{
+		Code:             input.Code,
+		ExecutionTimeout: input.ExecutionTimeout,
+	}, true
+}
+
+// FormatExecuteGoCodeToolCallMarkdown formats an execute_go_code tool call as markdown.
+// The output includes a header and a Go code block.
+func FormatExecuteGoCodeToolCallMarkdown(input ExecuteGoCodeFormatInput) string {
+	header := "#### [tool call]"
+	if input.ExecutionTimeout > 0 {
+		header = fmt.Sprintf("#### [tool call] (timeout: %ds)", input.ExecutionTimeout)
+	}
+	return fmt.Sprintf("%s\n```go\n%s\n```", header, input.Code)
+}
+
+// FormatExecuteGoCodeResultMarkdown formats an execute_go_code result as markdown.
+// The output includes a header and a shell code block.
+func FormatExecuteGoCodeResultMarkdown(content string, maxLines int) string {
+	truncated := truncateToMaxLines(content, maxLines)
+	return fmt.Sprintf("#### Code execution output:\n````shell\n%s\n````", truncated)
+}
+
+// IsExecuteGoCodeToolCall checks if a tool call JSON is for the execute_go_code tool.
+func IsExecuteGoCodeToolCall(content string) bool {
+	_, ok := ParseExecuteGoCodeToolCall(content)
+	return ok
+}
+
+// FormatGenericToolCallMarkdown formats a generic tool call JSON as markdown.
+// The output includes a header and a JSON code block with pretty-printing.
+// Returns the formatted content and true if formatting succeeded,
+// or the original content and false if JSON parsing failed.
+func FormatGenericToolCallMarkdown(content string) (string, bool) {
+	var formattedJson bytes.Buffer
+	if err := json.Indent(&formattedJson, []byte(content), "", "  "); err != nil {
+		return content, false
+	}
+	return fmt.Sprintf("#### [tool call]\n```json\n%s\n```", formattedJson.String()), true
+}
+
+// truncateToMaxLines truncates content to the specified number of lines.
+// If maxLines is <= 0, no truncation is performed and content is returned as-is.
+func truncateToMaxLines(content string, maxLines int) string {
+	if maxLines <= 0 {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	if len(lines) <= maxLines {
+		return content
+	}
+
+	return strings.Join(lines[:maxLines], "\n") + "\n... (truncated)"
+}

--- a/internal/agent/codemode_format_test.go
+++ b/internal/agent/codemode_format_test.go
@@ -1,0 +1,250 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseExecuteGoCodeToolCall(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantOk      bool
+		wantCode    string
+		wantTimeout int
+	}{
+		{
+			name:        "valid execute_go_code tool call",
+			content:     `{"name":"execute_go_code","parameters":{"code":"package main\n\nfunc Run() {}","executionTimeout":30}}`,
+			wantOk:      true,
+			wantCode:    "package main\n\nfunc Run() {}",
+			wantTimeout: 30,
+		},
+		{
+			name:        "valid execute_go_code without timeout",
+			content:     `{"name":"execute_go_code","parameters":{"code":"package main"}}`,
+			wantOk:      true,
+			wantCode:    "package main",
+			wantTimeout: 0,
+		},
+		{
+			name:    "different tool name",
+			content: `{"name":"get_weather","parameters":{"city":"NYC"}}`,
+			wantOk:  false,
+		},
+		{
+			name:    "empty code",
+			content: `{"name":"execute_go_code","parameters":{"code":""}}`,
+			wantOk:  false,
+		},
+		{
+			name:    "missing code field",
+			content: `{"name":"execute_go_code","parameters":{"executionTimeout":30}}`,
+			wantOk:  false,
+		},
+		{
+			name:    "malformed JSON",
+			content: `{invalid json`,
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := ParseExecuteGoCodeToolCall(tt.content)
+			if ok != tt.wantOk {
+				t.Errorf("ParseExecuteGoCodeToolCall() ok = %v, want %v", ok, tt.wantOk)
+				return
+			}
+			if tt.wantOk {
+				if input.Code != tt.wantCode {
+					t.Errorf("ParseExecuteGoCodeToolCall() code = %q, want %q", input.Code, tt.wantCode)
+				}
+				if input.ExecutionTimeout != tt.wantTimeout {
+					t.Errorf("ParseExecuteGoCodeToolCall() timeout = %d, want %d", input.ExecutionTimeout, tt.wantTimeout)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatExecuteGoCodeToolCallMarkdown(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ExecuteGoCodeFormatInput
+		want  string
+	}{
+		{
+			name: "with timeout",
+			input: ExecuteGoCodeFormatInput{
+				Code:             "package main\n\nfunc Run() {}",
+				ExecutionTimeout: 30,
+			},
+			want: "#### [tool call] (timeout: 30s)\n```go\npackage main\n\nfunc Run() {}\n```",
+		},
+		{
+			name: "without timeout",
+			input: ExecuteGoCodeFormatInput{
+				Code:             "package main",
+				ExecutionTimeout: 0,
+			},
+			want: "#### [tool call]\n```go\npackage main\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatExecuteGoCodeToolCallMarkdown(tt.input)
+			if got != tt.want {
+				t.Errorf("FormatExecuteGoCodeToolCallMarkdown() =\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatExecuteGoCodeResultMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		maxLines int
+		want     string
+	}{
+		{
+			name:     "short output",
+			content:  "Hello, World!",
+			maxLines: 20,
+			want:     "#### Code execution output:\n````shell\nHello, World!\n````",
+		},
+		{
+			name:     "output with truncation",
+			content:  "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+			maxLines: 3,
+			want:     "#### Code execution output:\n````shell\nLine 1\nLine 2\nLine 3\n... (truncated)\n````",
+		},
+		{
+			name:     "no truncation when maxLines is 0",
+			content:  "Line 1\nLine 2\nLine 3",
+			maxLines: 0,
+			want:     "#### Code execution output:\n````shell\nLine 1\nLine 2\nLine 3\n````",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatExecuteGoCodeResultMarkdown(tt.content, tt.maxLines)
+			if got != tt.want {
+				t.Errorf("FormatExecuteGoCodeResultMarkdown() =\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatGenericToolCallMarkdown(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantOk       bool
+		wantContains string
+	}{
+		{
+			name:         "valid JSON",
+			content:      `{"name":"get_weather","parameters":{"city":"NYC"}}`,
+			wantOk:       true,
+			wantContains: "get_weather",
+		},
+		{
+			name:    "malformed JSON",
+			content: `{invalid json`,
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := FormatGenericToolCallMarkdown(tt.content)
+			if ok != tt.wantOk {
+				t.Errorf("FormatGenericToolCallMarkdown() ok = %v, want %v", ok, tt.wantOk)
+			}
+			if tt.wantOk && !strings.Contains(result, tt.wantContains) {
+				t.Errorf("FormatGenericToolCallMarkdown() result doesn't contain %q, got %q", tt.wantContains, result)
+			}
+		})
+	}
+}
+
+func TestTruncateToMaxLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		maxLines int
+		want     string
+	}{
+		{
+			name:     "content shorter than max",
+			content:  "Line 1\nLine 2\nLine 3",
+			maxLines: 5,
+			want:     "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "content exactly at max",
+			content:  "Line 1\nLine 2\nLine 3",
+			maxLines: 3,
+			want:     "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "content longer than max",
+			content:  "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+			maxLines: 3,
+			want:     "Line 1\nLine 2\nLine 3\n... (truncated)",
+		},
+		{
+			name:     "maxLines is 0 - no truncation",
+			content:  "Line 1\nLine 2\nLine 3",
+			maxLines: 0,
+			want:     "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			maxLines: 5,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateToMaxLines(tt.content, tt.maxLines)
+			if got != tt.want {
+				t.Errorf("truncateToMaxLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsExecuteGoCodeToolCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "is execute_go_code",
+			content: `{"name":"execute_go_code","parameters":{"code":"package main"}}`,
+			want:    true,
+		},
+		{
+			name:    "is not execute_go_code",
+			content: `{"name":"get_weather","parameters":{}}`,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsExecuteGoCodeToolCall(tt.content)
+			if got != tt.want {
+				t.Errorf("IsExecuteGoCodeToolCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agent/tool_result_printer_test.go
+++ b/internal/agent/tool_result_printer_test.go
@@ -160,9 +160,9 @@ func TestTruncateToLines(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncateToLines(tt.content, tt.maxLines)
+			got := truncateToMaxLines(tt.content, tt.maxLines)
 			if got != tt.want {
-				t.Errorf("truncateToLines() = %q, want %q", got, tt.want)
+				t.Errorf("truncateToMaxLines() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #158 - Consistent output formatting for execute_go_code in conversation commands.

## Changes

- **New**: `internal/agent/codemode_format.go` - Shared formatting functions for execute_go_code tool calls and results
- **Updated**: `response_printer.go` - Uses shared formatting functions
- **Updated**: `tool_result_printer.go` - Uses shared formatting functions  
- **Updated**: `conversation.go` - Formats execute_go_code consistently with live sessions

## Details

The conversation print command (`cpe convo print`) now renders execute_go_code tool calls as Go code blocks and results as shell code blocks, matching the formatting used during live sessions.

Key implementation details:
- Shared `ParseExecuteGoCodeToolCall()` and `FormatExecuteGoCodeToolCallMarkdown()` functions eliminate duplication
- `isCodeModeResult()` properly matches tool call IDs to results, handling cases with multiple tool calls
- Comprehensive test coverage for all new functions

## Testing

- All existing tests pass
- Added tests for new formatting functions
- Added tests for `isCodeModeResult()` edge cases (multiple tool calls, ID matching)
- Added integration test for conversation formatting with execute_go_code